### PR TITLE
allow users to reduce metrics collected

### DIFF
--- a/jobs/loggr-system-metrics-agent-windows/monit
+++ b/jobs/loggr-system-metrics-agent-windows/monit
@@ -14,6 +14,7 @@
     "CA_CERT_PATH" => "/var/vcap/jobs/loggr-system-metrics-agent-windows/config/certs/system_metrics_agent_ca.crt",
     "CERT_PATH" => "/var/vcap/jobs/loggr-system-metrics-agent-windows/config/certs/system_metrics_agent.crt",
     "KEY_PATH" => "/var/vcap/jobs/loggr-system-metrics-agent-windows/config/certs/system_metrics_agent.key",
+    "LIMITED_METRICS" => p('bosh_metrics_forwarder_metrics_only'),
   }
 
   monit = {

--- a/jobs/loggr-system-metrics-agent-windows/spec
+++ b/jobs/loggr-system-metrics-agent-windows/spec
@@ -19,6 +19,9 @@ properties:
     description: |
       Port where the /metrics endpoint is served
     default: 9100
+  bosh_metrics_forwarder_metrics_only:
+    description: "reduces metrics emitted only to the metrics emitted by the bosh system metrics forwarder"
+    default: false
 
   sample_interval:
     description: |

--- a/jobs/loggr-system-metrics-agent/spec
+++ b/jobs/loggr-system-metrics-agent/spec
@@ -23,6 +23,9 @@ properties:
   sample_interval:
     description: "How often to record the system metrics"
     default: 1m
+  bosh_metrics_forwarder_metrics_only:
+    description: "reduces metrics emitted only to the metrics emitted by the bosh system metrics forwarder"
+    default: false
 
   system_metrics:
     tls:

--- a/jobs/loggr-system-metrics-agent/templates/ctl.erb
+++ b/jobs/loggr-system-metrics-agent/templates/ctl.erb
@@ -35,6 +35,7 @@ case $1 in
     JOB=<%= job %> \
     INDEX=<%= index %> \
     IP=<%= ip %> \
+    LIMITED_METRICS=<%= p('bosh_metrics_forwarder_metrics_only') %> \
     CA_CERT_PATH="/var/vcap/jobs/loggr-system-metrics-agent/config/certs/system_metrics_agent_ca.crt" \
     CERT_PATH="/var/vcap/jobs/loggr-system-metrics-agent/config/certs/system_metrics_agent.crt" \
     KEY_PATH="/var/vcap/jobs/loggr-system-metrics-agent/config/certs/system_metrics_agent.key" \

--- a/src/cmd/system-metrics-agent/app/config.go
+++ b/src/cmd/system-metrics-agent/app/config.go
@@ -15,8 +15,9 @@ type Config struct {
 	Index          string        `env:"INDEX, report"`
 	IP             string        `env:"IP, report"`
 
-	DebugPort  uint16 `env:"DEBUG_PORT, report"`
-	MetricPort uint16 `env:"METRIC_PORT, report, required"`
+	DebugPort      uint16 `env:"DEBUG_PORT, report"`
+	MetricPort     uint16 `env:"METRIC_PORT, report, required"`
+	LimitedMetrics bool   `env:"LIMITED_METRICS, report, required"`
 
 	CACertPath string `env:"CA_CERT_PATH, required, report"`
 	CertPath   string `env:"CERT_PATH, required, report"`

--- a/src/cmd/system-metrics-agent/app/system_metrics_agent.go
+++ b/src/cmd/system-metrics-agent/app/system_metrics_agent.go
@@ -1,19 +1,20 @@
 package app
 
 import (
-	"code.cloudfoundry.org/system-metrics/pkg/collector"
-	"code.cloudfoundry.org/system-metrics/pkg/egress/stats"
-	"code.cloudfoundry.org/tlsconfig"
 	"context"
 	"fmt"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"log"
 	"net"
 	"net/http"
 	_ "net/http/pprof"
 	"sync"
 	"time"
+
+	"code.cloudfoundry.org/system-metrics/pkg/collector"
+	"code.cloudfoundry.org/system-metrics/pkg/egress/stats"
+	"code.cloudfoundry.org/tlsconfig"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 const statOrigin = "system_metrics_agent"
@@ -100,7 +101,7 @@ func (a *SystemMetricsAgent) startMetricsServer(addr string) {
 
 	promRegisterer := prometheus.NewRegistry()
 	promRegistry := stats.NewPromRegistry(promRegisterer)
-	promSender := stats.NewPromSender(promRegistry, statOrigin, labels)
+	promSender := stats.NewPromSender(promRegistry, statOrigin, a.cfg.LimitedMetrics, labels)
 
 	router := http.NewServeMux()
 	router.Handle("/metrics", promhttp.HandlerFor(promRegisterer, promhttp.HandlerOpts{}))

--- a/src/pkg/egress/stats/prometheus_sender.go
+++ b/src/pkg/egress/stats/prometheus_sender.go
@@ -13,20 +13,22 @@ type GaugeRegistry interface {
 }
 
 type PromSender struct {
-	registry GaugeRegistry
-	origin   string
-	labels   map[string]string
+	registry       GaugeRegistry
+	origin         string
+	labels         map[string]string
+	limitedMetrics bool
 }
 
-func NewPromSender(registry GaugeRegistry, origin string, labels map[string]string) *PromSender {
+func NewPromSender(registry GaugeRegistry, origin string, limitedMetrics bool, labels map[string]string) *PromSender {
 	if labels == nil {
 		labels = make(map[string]string)
 	}
 	labels["origin"] = origin
 	return &PromSender{
-		registry: registry,
-		origin:   origin,
-		labels:   labels,
+		registry:       registry,
+		origin:         origin,
+		labels:         labels,
+		limitedMetrics: limitedMetrics,
 	}
 }
 
@@ -58,27 +60,31 @@ func (p PromSender) setSystemStats(stats collector.SystemStat) {
 	gauge = p.registry.Get("system_cpu_wait", p.origin, "Percent", labels)
 	gauge.Set(float64(stats.CPUStat.Wait))
 
-	gauge = p.registry.Get("system_cpu_idle", p.origin, "Percent", labels)
-	gauge.Set(float64(stats.CPUStat.Idle))
+	if !p.limitedMetrics {
+		gauge = p.registry.Get("system_cpu_idle", p.origin, "Percent", labels)
+		gauge.Set(float64(stats.CPUStat.Idle))
+	}
 
 	gauge = p.registry.Get("system_cpu_user", p.origin, "Percent", labels)
 	gauge.Set(float64(stats.CPUStat.User))
 
-	for _, perCoreStat := range stats.CPUCoreStats {
-		perCoreLabels := clone(p.labels)
-		perCoreLabels["cpu_name"] = perCoreStat.CPU
+	if !p.limitedMetrics {
+		for _, perCoreStat := range stats.CPUCoreStats {
+			perCoreLabels := clone(p.labels)
+			perCoreLabels["cpu_name"] = perCoreStat.CPU
 
-		gauge = p.registry.Get("system_cpu_core_sys", p.origin, "Percent", perCoreLabels)
-		gauge.Set(float64(perCoreStat.CPUStat.System))
+			gauge = p.registry.Get("system_cpu_core_sys", p.origin, "Percent", perCoreLabels)
+			gauge.Set(float64(perCoreStat.CPUStat.System))
 
-		gauge = p.registry.Get("system_cpu_core_wait", p.origin, "Percent", perCoreLabels)
-		gauge.Set(float64(perCoreStat.CPUStat.Wait))
+			gauge = p.registry.Get("system_cpu_core_wait", p.origin, "Percent", perCoreLabels)
+			gauge.Set(float64(perCoreStat.CPUStat.Wait))
 
-		gauge = p.registry.Get("system_cpu_core_idle", p.origin, "Percent", perCoreLabels)
-		gauge.Set(float64(perCoreStat.CPUStat.Idle))
+			gauge = p.registry.Get("system_cpu_core_idle", p.origin, "Percent", perCoreLabels)
+			gauge.Set(float64(perCoreStat.CPUStat.Idle))
 
-		gauge = p.registry.Get("system_cpu_core_user", p.origin, "Percent", perCoreLabels)
-		gauge.Set(float64(perCoreStat.CPUStat.User))
+			gauge = p.registry.Get("system_cpu_core_user", p.origin, "Percent", perCoreLabels)
+			gauge.Set(float64(perCoreStat.CPUStat.User))
+		}
 	}
 
 	gauge = p.registry.Get("system_mem_kb", p.origin, "KiB", labels)
@@ -96,33 +102,34 @@ func (p PromSender) setSystemStats(stats collector.SystemStat) {
 	gauge = p.registry.Get("system_load_1m", p.origin, "Load", labels)
 	gauge.Set(float64(stats.Load1M))
 
-	gauge = p.registry.Get("system_load_5m", p.origin, "Load", labels)
-	gauge.Set(float64(stats.Load5M))
+	if !p.limitedMetrics {
+		gauge = p.registry.Get("system_load_5m", p.origin, "Load", labels)
+		gauge.Set(float64(stats.Load5M))
 
-	gauge = p.registry.Get("system_load_15m", p.origin, "Load", labels)
-	gauge.Set(float64(stats.Load15M))
+		gauge = p.registry.Get("system_load_15m", p.origin, "Load", labels)
+		gauge.Set(float64(stats.Load15M))
 
-	gauge = p.registry.Get("system_network_ip_forwarding", p.origin, "", labels)
-	gauge.Set(float64(stats.ProtoCounters.IPForwarding))
+		gauge = p.registry.Get("system_network_ip_forwarding", p.origin, "", labels)
+		gauge.Set(float64(stats.ProtoCounters.IPForwarding))
 
-	gauge = p.registry.Get("system_network_udp_no_ports", p.origin, "", labels)
-	gauge.Set(float64(stats.ProtoCounters.UDPNoPorts))
+		gauge = p.registry.Get("system_network_udp_no_ports", p.origin, "", labels)
+		gauge.Set(float64(stats.ProtoCounters.UDPNoPorts))
 
-	gauge = p.registry.Get("system_network_udp_in_errors", p.origin, "", labels)
-	gauge.Set(float64(stats.ProtoCounters.UDPInErrors))
+		gauge = p.registry.Get("system_network_udp_in_errors", p.origin, "", labels)
+		gauge.Set(float64(stats.ProtoCounters.UDPInErrors))
 
-	gauge = p.registry.Get("system_network_udp_lite_in_errors", p.origin, "", labels)
-	gauge.Set(float64(stats.ProtoCounters.UDPLiteInErrors))
+		gauge = p.registry.Get("system_network_udp_lite_in_errors", p.origin, "", labels)
+		gauge.Set(float64(stats.ProtoCounters.UDPLiteInErrors))
 
-	gauge = p.registry.Get("system_network_tcp_active_opens", p.origin, "", labels)
-	gauge.Set(float64(stats.ProtoCounters.TCPActiveOpens))
+		gauge = p.registry.Get("system_network_tcp_active_opens", p.origin, "", labels)
+		gauge.Set(float64(stats.ProtoCounters.TCPActiveOpens))
 
-	gauge = p.registry.Get("system_network_tcp_curr_estab", p.origin, "", labels)
-	gauge.Set(float64(stats.ProtoCounters.TCPCurrEstab))
+		gauge = p.registry.Get("system_network_tcp_curr_estab", p.origin, "", labels)
+		gauge.Set(float64(stats.ProtoCounters.TCPCurrEstab))
 
-	gauge = p.registry.Get("system_network_tcp_retrans_segs", p.origin, "", labels)
-	gauge.Set(float64(stats.ProtoCounters.TCPRetransSegs))
-
+		gauge = p.registry.Get("system_network_tcp_retrans_segs", p.origin, "", labels)
+		gauge.Set(float64(stats.ProtoCounters.TCPRetransSegs))
+	}
 	if stats.Health.Present {
 		var healthValue float64
 		if stats.Health.Healthy {
@@ -135,6 +142,10 @@ func (p PromSender) setSystemStats(stats collector.SystemStat) {
 }
 
 func (p PromSender) setNetworkGauges(network collector.NetworkStat) {
+	if p.limitedMetrics {
+		return
+	}
+
 	labels := clone(p.labels)
 	labels["network_interface"] = network.Name
 
@@ -175,20 +186,22 @@ func (p PromSender) setSystemDiskGauges(stats collector.SystemStat) {
 	gauge = p.registry.Get("system_disk_system_inode_percent", p.origin, "Percent", labels)
 	gauge.Set(float64(stats.SystemDisk.InodePercent))
 
-	gauge = p.registry.Get("system_disk_system_read_bytes", p.origin, "Bytes", labels)
-	gauge.Set(float64(stats.SystemDisk.ReadBytes))
+	if !p.limitedMetrics {
+		gauge = p.registry.Get("system_disk_system_read_bytes", p.origin, "Bytes", labels)
+		gauge.Set(float64(stats.SystemDisk.ReadBytes))
 
-	gauge = p.registry.Get("system_disk_system_write_bytes", p.origin, "Bytes", labels)
-	gauge.Set(float64(stats.SystemDisk.WriteBytes))
+		gauge = p.registry.Get("system_disk_system_write_bytes", p.origin, "Bytes", labels)
+		gauge.Set(float64(stats.SystemDisk.WriteBytes))
 
-	gauge = p.registry.Get("system_disk_system_read_time", p.origin, "ms", labels)
-	gauge.Set(float64(stats.SystemDisk.ReadTime))
+		gauge = p.registry.Get("system_disk_system_read_time", p.origin, "ms", labels)
+		gauge.Set(float64(stats.SystemDisk.ReadTime))
 
-	gauge = p.registry.Get("system_disk_system_write_time", p.origin, "ms", labels)
-	gauge.Set(float64(stats.SystemDisk.WriteTime))
+		gauge = p.registry.Get("system_disk_system_write_time", p.origin, "ms", labels)
+		gauge.Set(float64(stats.SystemDisk.WriteTime))
 
-	gauge = p.registry.Get("system_disk_system_io_time", p.origin, "ms", labels)
-	gauge.Set(float64(stats.SystemDisk.IOTime))
+		gauge = p.registry.Get("system_disk_system_io_time", p.origin, "ms", labels)
+		gauge.Set(float64(stats.SystemDisk.IOTime))
+	}
 }
 
 func (p PromSender) setEphemeralDiskGauges(stats collector.SystemStat) {
@@ -203,20 +216,22 @@ func (p PromSender) setEphemeralDiskGauges(stats collector.SystemStat) {
 	gauge = p.registry.Get("system_disk_ephemeral_inode_percent", p.origin, "Percent", labels)
 	gauge.Set(float64(stats.EphemeralDisk.InodePercent))
 
-	gauge = p.registry.Get("system_disk_ephemeral_read_bytes", p.origin, "Bytes", labels)
-	gauge.Set(float64(stats.EphemeralDisk.ReadBytes))
+	if !p.limitedMetrics {
+		gauge = p.registry.Get("system_disk_ephemeral_read_bytes", p.origin, "Bytes", labels)
+		gauge.Set(float64(stats.EphemeralDisk.ReadBytes))
 
-	gauge = p.registry.Get("system_disk_ephemeral_write_bytes", p.origin, "Bytes", labels)
-	gauge.Set(float64(stats.EphemeralDisk.WriteBytes))
+		gauge = p.registry.Get("system_disk_ephemeral_write_bytes", p.origin, "Bytes", labels)
+		gauge.Set(float64(stats.EphemeralDisk.WriteBytes))
 
-	gauge = p.registry.Get("system_disk_ephemeral_read_time", p.origin, "ms", labels)
-	gauge.Set(float64(stats.EphemeralDisk.ReadTime))
+		gauge = p.registry.Get("system_disk_ephemeral_read_time", p.origin, "ms", labels)
+		gauge.Set(float64(stats.EphemeralDisk.ReadTime))
 
-	gauge = p.registry.Get("system_disk_ephemeral_write_time", p.origin, "ms", labels)
-	gauge.Set(float64(stats.EphemeralDisk.WriteTime))
+		gauge = p.registry.Get("system_disk_ephemeral_write_time", p.origin, "ms", labels)
+		gauge.Set(float64(stats.EphemeralDisk.WriteTime))
 
-	gauge = p.registry.Get("system_disk_ephemeral_io_time", p.origin, "ms", labels)
-	gauge.Set(float64(stats.EphemeralDisk.IOTime))
+		gauge = p.registry.Get("system_disk_ephemeral_io_time", p.origin, "ms", labels)
+		gauge.Set(float64(stats.EphemeralDisk.IOTime))
+	}
 }
 
 func (p PromSender) setPersistentDiskGauges(stats collector.SystemStat) {
@@ -231,18 +246,20 @@ func (p PromSender) setPersistentDiskGauges(stats collector.SystemStat) {
 	gauge = p.registry.Get("system_disk_persistent_inode_percent", p.origin, "Percent", labels)
 	gauge.Set(float64(stats.PersistentDisk.InodePercent))
 
-	gauge = p.registry.Get("system_disk_persistent_read_bytes", p.origin, "Bytes", labels)
-	gauge.Set(float64(stats.PersistentDisk.ReadBytes))
+	if !p.limitedMetrics {
+		gauge = p.registry.Get("system_disk_persistent_read_bytes", p.origin, "Bytes", labels)
+		gauge.Set(float64(stats.PersistentDisk.ReadBytes))
 
-	gauge = p.registry.Get("system_disk_persistent_write_bytes", p.origin, "Bytes", labels)
-	gauge.Set(float64(stats.PersistentDisk.WriteBytes))
+		gauge = p.registry.Get("system_disk_persistent_write_bytes", p.origin, "Bytes", labels)
+		gauge.Set(float64(stats.PersistentDisk.WriteBytes))
 
-	gauge = p.registry.Get("system_disk_persistent_read_time", p.origin, "ms", labels)
-	gauge.Set(float64(stats.PersistentDisk.ReadTime))
+		gauge = p.registry.Get("system_disk_persistent_read_time", p.origin, "ms", labels)
+		gauge.Set(float64(stats.PersistentDisk.ReadTime))
 
-	gauge = p.registry.Get("system_disk_persistent_write_time", p.origin, "ms", labels)
-	gauge.Set(float64(stats.PersistentDisk.WriteTime))
+		gauge = p.registry.Get("system_disk_persistent_write_time", p.origin, "ms", labels)
+		gauge.Set(float64(stats.PersistentDisk.WriteTime))
 
-	gauge = p.registry.Get("system_disk_persistent_io_time", p.origin, "ms", labels)
-	gauge.Set(float64(stats.PersistentDisk.IOTime))
+		gauge = p.registry.Get("system_disk_persistent_io_time", p.origin, "ms", labels)
+		gauge.Set(float64(stats.PersistentDisk.IOTime))
+	}
 }

--- a/src/pkg/egress/stats/prometheus_sender_test.go
+++ b/src/pkg/egress/stats/prometheus_sender_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Prometheus Sender", func() {
 			"ip":         "test-ip",
 		}
 
-		sender = stats.NewPromSender(registry, "test-origin", labels)
+		sender = stats.NewPromSender(registry, "test-origin", false, labels)
 	})
 
 	It("gets the correct number of metrics from the registry", func() {
@@ -35,7 +35,7 @@ var _ = Describe("Prometheus Sender", func() {
 	})
 
 	It("does not panic with no default labels", func() {
-		stats.NewPromSender(registry, "test-origin", nil)
+		stats.NewPromSender(registry, "test-origin", false, nil)
 	})
 
 	DescribeTable("default tags", func(tag, value string) {
@@ -112,6 +112,97 @@ var _ = Describe("Prometheus Sender", func() {
 		Entry("system_disk_persistent_write_time", "system_disk_persistent_write_time", map[string]string{"origin": "test-origin"}, "ms", 4000.0),
 		Entry("system_disk_persistent_io_time", "system_disk_persistent_io_time", map[string]string{"origin": "test-origin"}, "ms", 5000.0),
 		Entry("system_healthy", "system_healthy", map[string]string{"origin": "test-origin"}, "", 1.0),
+	)
+
+	DescribeTable("limited metrics", func(name string, tags map[string]string, unit string, exists bool) {
+		sender = stats.NewPromSender(registry, "test-origin", true, labels)
+		sender.Send(defaultInput)
+
+		cpuName := ""
+		if cpuTag, ok := tags["cpu_name"]; ok {
+			cpuName = cpuTag
+		}
+
+		keyName := name + tags["origin"] + unit + cpuName
+		gauge := registry.gauges[keyName]
+
+		if exists {
+			Expect(gauge).NotTo(BeNil())
+			Expect(gauge.value).ToNot(BeZero())
+			for k, v := range tags {
+				Expect(gauge.tags[k]).To(Equal(v))
+			}
+		} else {
+			Expect(gauge).To(BeNil())
+		}
+	},
+		Entry("system_mem_kb", "system_mem_kb", map[string]string{"origin": "test-origin"}, "KiB", true),
+		Entry("system_mem_percent", "system_mem_percent", map[string]string{"origin": "test-origin"}, "Percent", true),
+		Entry("system_swap_kb", "system_swap_kb", map[string]string{"origin": "test-origin"}, "KiB", true),
+		Entry("system_swap_percent", "system_swap_percent", map[string]string{"origin": "test-origin"}, "Percent", true),
+		Entry("system_load_1m", "system_load_1m", map[string]string{"origin": "test-origin"}, "Load", true),
+		Entry("system_load_5m", "system_load_5m", map[string]string{"origin": "test-origin"}, "Load", false),
+		Entry("system_load_15m", "system_load_15m", map[string]string{"origin": "test-origin"}, "Load", false),
+		Entry("system_cpu_user", "system_cpu_user", map[string]string{"origin": "test-origin"}, "Percent", true),
+		Entry("system_cpu_sys", "system_cpu_sys", map[string]string{"origin": "test-origin"}, "Percent", true),
+		Entry("system_cpu_idle", "system_cpu_idle", map[string]string{"origin": "test-origin"}, "Percent", false),
+		Entry("system_cpu_wait", "system_cpu_wait", map[string]string{"origin": "test-origin"}, "Percent", true),
+		Entry("system cpu core 1 user", "system_cpu_core_user", map[string]string{"origin": "test-origin", "cpu_name": "cpu1"}, "Percent", false),
+		Entry("system cpu core 1 sys", "system_cpu_core_sys", map[string]string{"origin": "test-origin", "cpu_name": "cpu1"}, "Percent", false),
+		Entry("system cpu core 1 idle", "system_cpu_core_idle", map[string]string{"origin": "test-origin", "cpu_name": "cpu1"}, "Percent", false),
+		Entry("system cpu core 1 wait", "system_cpu_core_wait", map[string]string{"origin": "test-origin", "cpu_name": "cpu1"}, "Percent", false),
+		Entry("system cpu core 2 user", "system_cpu_core_user", map[string]string{"origin": "test-origin", "cpu_name": "cpu2"}, "Percent", false),
+		Entry("system cpu core 2 sys", "system_cpu_core_sys", map[string]string{"origin": "test-origin", "cpu_name": "cpu2"}, "Percent", false),
+		Entry("system cpu core 2 idle", "system_cpu_core_idle", map[string]string{"origin": "test-origin", "cpu_name": "cpu2"}, "Percent", false),
+		Entry("system cpu core 2 wait", "system_cpu_core_wait", map[string]string{"origin": "test-origin", "cpu_name": "cpu2"}, "Percent", false),
+		Entry("system_disk_system_percent", "system_disk_system_percent", map[string]string{"origin": "test-origin"}, "Percent", true),
+		Entry("system_disk_system_inode_percent", "system_disk_system_inode_percent", map[string]string{"origin": "test-origin"}, "Percent", true),
+		Entry("system_disk_system_read_bytes", "system_disk_system_read_bytes", map[string]string{"origin": "test-origin"}, "Bytes", false),
+		Entry("system_disk_system_write_bytes", "system_disk_system_write_bytes", map[string]string{"origin": "test-origin"}, "Bytes", false),
+		Entry("system_disk_system_read_time", "system_disk_system_read_time", map[string]string{"origin": "test-origin"}, "ms", false),
+		Entry("system_disk_system_write_time", "system_disk_system_write_time", map[string]string{"origin": "test-origin"}, "ms", false),
+		Entry("system_disk_system_io_time", "system_disk_system_io_time", map[string]string{"origin": "test-origin"}, "ms", false),
+		Entry("system_disk_ephemeral_percent", "system_disk_ephemeral_percent", map[string]string{"origin": "test-origin"}, "Percent", true),
+		Entry("system_disk_ephemeral_inode_percent", "system_disk_ephemeral_inode_percent", map[string]string{"origin": "test-origin"}, "Percent", true),
+		Entry("system_disk_ephemeral_read_bytes", "system_disk_ephemeral_read_bytes", map[string]string{"origin": "test-origin"}, "Bytes", false),
+		Entry("system_disk_ephemeral_write_bytes", "system_disk_ephemeral_write_bytes", map[string]string{"origin": "test-origin"}, "Bytes", false),
+		Entry("system_disk_ephemeral_read_time", "system_disk_ephemeral_read_time", map[string]string{"origin": "test-origin"}, "ms", false),
+		Entry("system_disk_ephemeral_write_time", "system_disk_ephemeral_write_time", map[string]string{"origin": "test-origin"}, "ms", false),
+		Entry("system_disk_ephemeral_io_time", "system_disk_ephemeral_io_time", map[string]string{"origin": "test-origin"}, "ms", false),
+		Entry("system_disk_persistent_percent", "system_disk_persistent_percent", map[string]string{"origin": "test-origin"}, "Percent", true),
+		Entry("system_disk_persistent_inode_percent", "system_disk_persistent_inode_percent", map[string]string{"origin": "test-origin"}, "Percent", true),
+		Entry("system_disk_persistent_read_bytes", "system_disk_persistent_read_bytes", map[string]string{"origin": "test-origin"}, "Bytes", false),
+		Entry("system_disk_persistent_write_bytes", "system_disk_persistent_write_bytes", map[string]string{"origin": "test-origin"}, "Bytes", false),
+		Entry("system_disk_persistent_read_time", "system_disk_persistent_read_time", map[string]string{"origin": "test-origin"}, "ms", false),
+		Entry("system_disk_persistent_write_time", "system_disk_persistent_write_time", map[string]string{"origin": "test-origin"}, "ms", false),
+		Entry("system_disk_persistent_io_time", "system_disk_persistent_io_time", map[string]string{"origin": "test-origin"}, "ms", false),
+		Entry("system_healthy", "system_healthy", map[string]string{"origin": "test-origin"}, "", true),
+	)
+
+	DescribeTable("network metrics with limited metrics", func(name, origin, unit, networkName string) {
+		sender = stats.NewPromSender(registry, "test-origin", true, labels)
+		sender.Send(networkInput)
+
+		_, exists := registry.gauges[name+origin+unit+networkName]
+		Expect(exists).To(BeFalse())
+	},
+		Entry("system_network_bytes_sent", "system_network_bytes_sent", "test-origin", "Bytes", "eth0"),
+		Entry("system_network_bytes_received", "system_network_bytes_received", "test-origin", "Bytes", "eth0"),
+		Entry("system_network_packets_sent", "system_network_packets_sent", "test-origin", "Packets", "eth0"),
+		Entry("system_network_packets_received", "system_network_packets_received", "test-origin", "Packets", "eth0"),
+		Entry("system_network_error_in", "system_network_error_in", "test-origin", "Frames", "eth0"),
+		Entry("system_network_error_out", "system_network_error_out", "test-origin", "Frames", "eth0"),
+		Entry("system_network_drop_in", "system_network_drop_in", "test-origin", "Packets", "eth0"),
+		Entry("system_network_drop_out", "system_network_drop_out", "test-origin", "Packets", "eth0"),
+
+		Entry("system_network_bytes_sent", "system_network_bytes_sent", "test-origin", "Bytes", "eth1"),
+		Entry("system_network_bytes_received", "system_network_bytes_received", "test-origin", "Bytes", "eth1"),
+		Entry("system_network_packets_sent", "system_network_packets_sent", "test-origin", "Packets", "eth1"),
+		Entry("system_network_packets_received", "system_network_packets_received", "test-origin", "Packets", "eth1"),
+		Entry("system_network_error_in", "system_network_error_in", "test-origin", "Frames", "eth1"),
+		Entry("system_network_error_out", "system_network_error_out", "test-origin", "Frames", "eth1"),
+		Entry("system_network_drop_in", "system_network_drop_in", "test-origin", "Packets", "eth1"),
+		Entry("system_network_drop_out", "system_network_drop_out", "test-origin", "Packets", "eth1"),
 	)
 
 	DescribeTable("network metrics", func(name, origin, unit, networkName string, value float64) {


### PR DESCRIPTION
- this will be the same set of metrics that was collected by the bosh-system-metrics-forwarder-release

Signed-off-by: Seth Boyles <sboyles@vmware.com>

## Description

Allows operators to use a limited set of metrics (that matches the metrices exported by `bosh-system-metrics-forwarder-release`, which would allow us to ultimately replace the `bosh-system-metrics-forwarder-release` with the `system-metrics-release`)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [ ] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

