### PR TITLE
Fix cpu metrics

### DIFF
--- a/jobs/loggr-system-metrics-agent/spec
+++ b/jobs/loggr-system-metrics-agent/spec
@@ -22,7 +22,7 @@ properties:
     default: 14922
   sample_interval:
     description: "How often to record the system metrics"
-    default: 1m
+    default: 15s
   bosh_metrics_forwarder_metrics_only:
     description: "reduces metrics emitted only to the metrics emitted by the bosh system metrics forwarder"
     default: false

--- a/src/cmd/system-metrics-agent/app/config.go
+++ b/src/cmd/system-metrics-agent/app/config.go
@@ -26,7 +26,7 @@ type Config struct {
 
 func LoadConfig() Config {
 	cfg := Config{
-		SampleInterval: time.Minute,
+		SampleInterval: time.Second * 15,
 		MetricPort:     0,
 	}
 

--- a/src/pkg/collector/collector.go
+++ b/src/pkg/collector/collector.go
@@ -135,7 +135,7 @@ func New(log *log.Logger, opts ...CollectorOption) Collector {
 	return c
 }
 
-func (c Collector) Collect() (SystemStat, error) {
+func (c *Collector) Collect() (SystemStat, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 


### PR DESCRIPTION
# Description

CPU metrics were not saving the previous sample successfully so the CPU percentage was always calculated since the agent booted. This made CPU metrics barely change at all and not be useful.

In the future we could also expose CPU time instead of or in addition to the percentages which would lead to better precision and be resistant to sample loss.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [X] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [X] I have added testing for my changes

/cc @sethboyles 
