### PR TITLE
Ensure LIMITED_METRICS val is interpreted as bool

### DIFF
--- a/jobs/loggr-system-metrics-agent-windows/monit
+++ b/jobs/loggr-system-metrics-agent-windows/monit
@@ -14,7 +14,7 @@
     "CA_CERT_PATH" => "/var/vcap/jobs/loggr-system-metrics-agent-windows/config/certs/system_metrics_agent_ca.crt",
     "CERT_PATH" => "/var/vcap/jobs/loggr-system-metrics-agent-windows/config/certs/system_metrics_agent.crt",
     "KEY_PATH" => "/var/vcap/jobs/loggr-system-metrics-agent-windows/config/certs/system_metrics_agent.key",
-    "LIMITED_METRICS" => p('bosh_metrics_forwarder_metrics_only'),
+    "LIMITED_METRICS" => p('bosh_metrics_forwarder_metrics_only').to_s,
   }
 
   monit = {


### PR DESCRIPTION
# Description

This commit ensures that users will not encounter the following error while deploying `system-metrics` on Windows stemcells:

```
Task 14 | 03:07:40 | L starting jobs: no_op/fb4da847-c87e-4532-9cce-9ae174d9520d (0) (canary) (00:00:30)
                   L Error: Action Failed start: Configuring jobs: Configuring job loggr-system-metrics-agent-windows: Adding monit configuration: json: cannot unmarshal bool into Go value of type string
Task 14 | 03:07:41 | Error: Action Failed start: Configuring jobs: Configuring job loggr-system-metrics-agent-windows: Adding monit configuration: json: cannot unmarshal bool into Go value of type string
```

This was brought to our attention via a trouble report in an internal Slack channel.

Signed-off-by: Ben Fuller <benjaminf@vmware.com>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [x] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

