### PR TITLE
fix MemPercent to be 0-100 instead of 0-1

### DIFF
--- a/src/pkg/collector/collector.go
+++ b/src/pkg/collector/collector.go
@@ -206,7 +206,7 @@ func (c *Collector) Collect() (SystemStat, error) {
 		CPUCoreStats: coreStats,
 
 		MemKB:      (m.Total - m.Available) / 1024,
-		MemPercent: float64(m.Total-m.Available) / float64(m.Total),
+		MemPercent: float64(m.Total-m.Available) / float64(m.Total) * 100,
 
 		SwapKB:      s.Used / 1024,
 		SwapPercent: s.UsedPercent,

--- a/src/pkg/collector/collector_test.go
+++ b/src/pkg/collector/collector_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Collector", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(stats.MemKB).To(Equal(uint64(1)))
-		Expect(stats.MemPercent).To(Equal(0.5))
+		Expect(stats.MemPercent).To(Equal(50.0))
 	})
 
 	It("returns the swap metrics", func() {


### PR DESCRIPTION
This error was introduced in 308f64ab2245d69c8d9a4e91c1e5317d65ae2f91 when we updated the free memory algorithm.

It should be noted that if someone set up dashboards in the last month using the observed 0-1 values this fix may be surprising. It's still the right thing to do though, the metric is called percent and used to use 0-100 as the range.

Signed-off-by: Matthew Kocher <mkocher@vmware.com>

# Description

Please include a summary of the change.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [X] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [X] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)

