### PR TITLE
CI: use regex for release branches in actions triggers

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -61,6 +61,8 @@ jobs:
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2
+      with:
+        working-directory: src
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,14 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+    - main
+    - v[0-9]*
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches:
+    - main
+    - v[0-9]*
   schedule:
     - cron: '40 1 * * 2'
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
     - main
+    - v[0-9]*
   pull_request:
     branches:
     - main
+    - v[0-9]*
   schedule:
   - cron: '40 1 * * 2'
 


### PR DESCRIPTION
# Description

Use the same regex that we use for branch protections for our GH actions triggers. This makes it so that when we split out version branches in the future, GH actions will successfully work on those branches out of the box.

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
