### PR TITLE
add physical core count and threads per core to system metrics agent

### DIFF
--- a/scripts/integration-tests.sh
+++ b/scripts/integration-tests.sh
@@ -15,7 +15,9 @@ system_cpu_core_sys
 system_cpu_core_user
 system_cpu_core_wait
 system_cpu_idle
+system_cpu_physical_core_count
 system_cpu_sys
+system_cpu_threads_per_core
 system_cpu_user
 system_cpu_wait
 system_disk_ephemeral_inode_percent

--- a/src/cmd/system-metrics-agent/app/system_metrics_agent_test.go
+++ b/src/cmd/system-metrics-agent/app/system_metrics_agent_test.go
@@ -119,7 +119,7 @@ var _ = Describe("SystemMetricsAgent", func() {
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		body, err := io.ReadAll(resp.Body)
 		Expect(err).To(BeNil())
-		Expect(strings.Count(string(body), "\n")).To(Equal(120))
+		Expect(strings.Count(string(body), "\n")).To(Equal(126))
 	})
 
 	It("limits metrics emitted", func() {
@@ -161,7 +161,7 @@ var _ = Describe("SystemMetricsAgent", func() {
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		body, err := io.ReadAll(resp.Body)
 		Expect(err).To(BeNil())
-		Expect(strings.Count(string(body), "\n")).To(Equal(45))
+		Expect(strings.Count(string(body), "\n")).To(Equal(51))
 	})
 
 	It("contains default prom labels", func() {

--- a/src/pkg/egress/stats/prometheus_sender.go
+++ b/src/pkg/egress/stats/prometheus_sender.go
@@ -65,6 +65,12 @@ func (p PromSender) setSystemStats(stats collector.SystemStat) {
 		gauge.Set(float64(stats.CPUStat.Idle))
 	}
 
+	gauge = p.registry.Get("system_cpu_physical_core_count", p.origin, "Cores", labels)
+	gauge.Set(float64(stats.CPUPhysicalCoreCount))
+
+	gauge = p.registry.Get("system_cpu_threads_per_core", p.origin, "Threads", labels)
+	gauge.Set(float64(stats.CPUThreadsPerCore))
+
 	gauge = p.registry.Get("system_cpu_user", p.origin, "Percent", labels)
 	gauge.Set(float64(stats.CPUStat.User))
 

--- a/src/pkg/egress/stats/prometheus_sender_test.go
+++ b/src/pkg/egress/stats/prometheus_sender_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Prometheus Sender", func() {
 	It("gets the correct number of metrics from the registry", func() {
 		sender.Send(defaultInput)
 
-		Expect(registry.gaugeCount).To(Equal(52))
+		Expect(registry.gaugeCount).To(Equal(50))
 	})
 
 	It("does not panic with no default labels", func() {
@@ -81,6 +81,8 @@ var _ = Describe("Prometheus Sender", func() {
 		Entry("system_cpu_sys", "system_cpu_sys", map[string]string{"origin": "test-origin"}, "Percent", 52.52),
 		Entry("system_cpu_idle", "system_cpu_idle", map[string]string{"origin": "test-origin"}, "Percent", 10.10),
 		Entry("system_cpu_wait", "system_cpu_wait", map[string]string{"origin": "test-origin"}, "Percent", 22.22),
+		Entry("system_cpu_physical_core_count", "system_cpu_physical_core_count", map[string]string{"origin": "test-origin"}, "Cores", 1.0),
+		Entry("system_cpu_threads_per_core", "system_cpu_threads_per_core", map[string]string{"origin": "test-origin"}, "Threads", 2.0),
 		Entry("system cpu core 1 user", "system_cpu_core_user", map[string]string{"origin": "test-origin", "cpu_name": "cpu1"}, "Percent", 25.25),
 		Entry("system cpu core 1 sys", "system_cpu_core_sys", map[string]string{"origin": "test-origin", "cpu_name": "cpu1"}, "Percent", 52.52),
 		Entry("system cpu core 1 idle", "system_cpu_core_idle", map[string]string{"origin": "test-origin", "cpu_name": "cpu1"}, "Percent", 10.10),

--- a/src/pkg/egress/stats/stats_suite_test.go
+++ b/src/pkg/egress/stats/stats_suite_test.go
@@ -32,6 +32,9 @@ var (
 			Wait:   22.22,
 		},
 
+		CPUPhysicalCoreCount: 1,
+		CPUThreadsPerCore:    2,
+
 		CPUCoreStats: []collector.CPUCoreStat{
 			{
 				CPU: "cpu1",
@@ -44,15 +47,6 @@ var (
 			},
 			{
 				CPU: "cpu2",
-				CPUStat: collector.CPUStat{
-					User:   25.25,
-					System: 52.52,
-					Idle:   10.10,
-					Wait:   22.22,
-				},
-			},
-			{
-				CPU: "cpu3",
 				CPUStat: collector.CPUStat{
 					User:   25.25,
 					System: 52.52,


### PR DESCRIPTION
# Description

Adding physical core and threads per core metrics to the system metrics agent.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [X] Unit tests
- [X] Integration tests
- [X] Acceptance tests

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [X] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)

