### PR TITLE
Fix: go module name

### DIFF
--- a/src/cmd/system-metrics-agent/app/system_metrics_agent.go
+++ b/src/cmd/system-metrics-agent/app/system_metrics_agent.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 	"time"
 
-	"code.cloudfoundry.org/system-metrics/pkg/collector"
-	"code.cloudfoundry.org/system-metrics/pkg/egress/stats"
+	"code.cloudfoundry.org/system-metrics-release/src/pkg/collector"
+	"code.cloudfoundry.org/system-metrics-release/src/pkg/egress/stats"
 	"code.cloudfoundry.org/tlsconfig"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"

--- a/src/cmd/system-metrics-agent/app/system_metrics_agent_test.go
+++ b/src/cmd/system-metrics-agent/app/system_metrics_agent_test.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"time"
 
-	"code.cloudfoundry.org/system-metrics/pkg/collector"
+	"code.cloudfoundry.org/system-metrics-release/src/pkg/collector"
 
-	"code.cloudfoundry.org/system-metrics/cmd/system-metrics-agent/app"
-	"code.cloudfoundry.org/system-metrics/internal/testhelper"
+	"code.cloudfoundry.org/system-metrics-release/src/cmd/system-metrics-agent/app"
+	"code.cloudfoundry.org/system-metrics-release/src/internal/testhelper"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/src/cmd/system-metrics-agent/main.go
+++ b/src/cmd/system-metrics-agent/main.go
@@ -4,9 +4,9 @@ import (
 	"log"
 	"os"
 
-	"code.cloudfoundry.org/system-metrics/pkg/collector"
+	"code.cloudfoundry.org/system-metrics-release/src/pkg/collector"
 
-	"code.cloudfoundry.org/system-metrics/cmd/system-metrics-agent/app"
+	"code.cloudfoundry.org/system-metrics-release/src/cmd/system-metrics-agent/app"
 )
 
 func main() {

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,4 +1,4 @@
-module code.cloudfoundry.org/system-metrics
+module code.cloudfoundry.org/system-metrics-release/src
 
 go 1.20
 

--- a/src/pkg/collector/collector_test.go
+++ b/src/pkg/collector/collector_test.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"syscall"
 
-	"code.cloudfoundry.org/system-metrics/pkg/collector"
+	"code.cloudfoundry.org/system-metrics-release/src/pkg/collector"
 	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/shirou/gopsutil/v3/disk"
 	"github.com/shirou/gopsutil/v3/load"

--- a/src/pkg/collector/processor_test.go
+++ b/src/pkg/collector/processor_test.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"time"
 
-	"code.cloudfoundry.org/system-metrics/pkg/collector"
+	"code.cloudfoundry.org/system-metrics-release/src/pkg/collector"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/src/pkg/egress/stats/prom_registry_test.go
+++ b/src/pkg/egress/stats/prom_registry_test.go
@@ -1,7 +1,7 @@
 package stats_test
 
 import (
-	"code.cloudfoundry.org/system-metrics/pkg/egress/stats"
+	"code.cloudfoundry.org/system-metrics-release/src/pkg/egress/stats"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus"

--- a/src/pkg/egress/stats/prometheus_sender.go
+++ b/src/pkg/egress/stats/prometheus_sender.go
@@ -1,7 +1,7 @@
 package stats
 
 import (
-	"code.cloudfoundry.org/system-metrics/pkg/collector"
+	"code.cloudfoundry.org/system-metrics-release/src/pkg/collector"
 )
 
 type Gauge interface {

--- a/src/pkg/egress/stats/prometheus_sender_test.go
+++ b/src/pkg/egress/stats/prometheus_sender_test.go
@@ -1,8 +1,8 @@
 package stats_test
 
 import (
-	"code.cloudfoundry.org/system-metrics/pkg/collector"
-	"code.cloudfoundry.org/system-metrics/pkg/egress/stats"
+	"code.cloudfoundry.org/system-metrics-release/src/pkg/collector"
+	"code.cloudfoundry.org/system-metrics-release/src/pkg/egress/stats"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/src/pkg/egress/stats/stats_suite_test.go
+++ b/src/pkg/egress/stats/stats_suite_test.go
@@ -3,7 +3,7 @@ package stats_test
 import (
 	"testing"
 
-	"code.cloudfoundry.org/system-metrics/pkg/collector"
+	"code.cloudfoundry.org/system-metrics-release/src/pkg/collector"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )


### PR DESCRIPTION
Replaces the go module path with a path that actually resolves to the go.mod file.