### PR TITLE
feat: clock drift monitoring (opt-in, PCI-DSS 10.6)

### DIFF
--- a/docs/clock_drift_metrics.md
+++ b/docs/clock_drift_metrics.md
@@ -1,0 +1,25 @@
+# Clock Drift Metrics
+
+When the `clock_drift_enabled` BOSH property is set to `true`, the `system-metrics-agent` emits a lean set of metric families designed to satisfy PCI-DSS 10.6 audit requirements while providing essential operational visibility.
+
+These metrics are collected by executing `chronyc tracking` on the host VM.
+
+## PCI-DSS Audit Evidence (The "Must Haves")
+
+These metrics provide the core evidence required by auditors to verify that critical systems are synchronized to a single, consistent time source.
+
+*   **`clock_drift_last_offset_seconds` (Gauge)**: The raw offset from the last chrony poll. Proves the clock is actively synchronized within acceptable bounds.
+*   **`clock_drift_leap_status` (Gauge)**: One-hot encoded status (`normal`, `insert`, `delete`, `unsync`, `unknown`). A value of `1.0` for `status="unsync"` is an immediate compliance failure and should trigger a Sev1 alert.
+*   **`clock_drift_reference_info` (Gauge)**: Emits `1.0` with labels for `reference_id` (decoded to IP or ASCII) and `reference_host`. Proves all systems are acquiring time from the approved corporate time source.
+*   **`clock_drift_collection_errors` (Gauge)**: Monotonically increasing counter of chronyc execution/parsing failures.
+
+## Operational Best Practices (The "Highly Recommended")
+
+These metrics provide additional context for platform engineers to diagnose time synchronization issues.
+
+*   **`clock_drift_system_time_offset_seconds` (Gauge)**: The smoothed system time offset. Often better for alerting than the raw `last_offset` to avoid false positives.
+*   **`clock_drift_stratum` (Gauge)**: The NTP stratum of the reference clock. An excellent at-a-glance health indicator for the foundation's time hierarchy.
+*   **`clock_drift_frequency_ppm` (Gauge)**: The natural drift rate of the hardware clock. Massive spikes indicate underlying IaaS/hypervisor hardware issues.
+*   **`clock_drift_root_delay_seconds` (Gauge)**: Network latency to the root time source. Useful for diagnosing UDP throttling or routing issues.
+
+*(Note: Deeply technical chrony-internal smoothing metrics like RMS offset, skew, and dispersion have been explicitly excluded to minimize Prometheus cardinality and dashboard noise.)*

--- a/jobs/loggr-system-metrics-agent-windows/spec
+++ b/jobs/loggr-system-metrics-agent-windows/spec
@@ -22,7 +22,6 @@ properties:
   bosh_metrics_forwarder_metrics_only:
     description: "reduces metrics emitted only to the metrics emitted by the bosh system metrics forwarder"
     default: false
-
   sample_interval:
     description: |
       How often to record the system metrics

--- a/jobs/loggr-system-metrics-agent-windows/spec
+++ b/jobs/loggr-system-metrics-agent-windows/spec
@@ -22,6 +22,7 @@ properties:
   bosh_metrics_forwarder_metrics_only:
     description: "reduces metrics emitted only to the metrics emitted by the bosh system metrics forwarder"
     default: false
+
   sample_interval:
     description: |
       How often to record the system metrics

--- a/jobs/loggr-system-metrics-agent/spec
+++ b/jobs/loggr-system-metrics-agent/spec
@@ -26,6 +26,9 @@ properties:
   bosh_metrics_forwarder_metrics_only:
     description: "reduces metrics emitted only to the metrics emitted by the bosh system metrics forwarder"
     default: false
+  clock_drift_enabled:
+    description: "enables NTP clock-drift monitoring via chronyc for PCI-DSS 10.6 compliance. Disabled by default."
+    default: false
 
   system_metrics:
     tls:

--- a/jobs/loggr-system-metrics-agent/templates/bpm.yml.erb
+++ b/jobs/loggr-system-metrics-agent/templates/bpm.yml.erb
@@ -10,6 +10,7 @@ processes:
     INDEX: "<%= spec.id || spec.index.to_s %>"
     IP: "<%= spec.ip %>"
     LIMITED_METRICS: "<%= p('bosh_metrics_forwarder_metrics_only') %>"
+    CLOCK_DRIFT_ENABLED: "<%= p('clock_drift_enabled') %>"
     CA_CERT_PATH: /var/vcap/jobs/loggr-system-metrics-agent/config/certs/system_metrics_agent_ca.crt
     CERT_PATH: /var/vcap/jobs/loggr-system-metrics-agent/config/certs/system_metrics_agent.crt
     KEY_PATH: /var/vcap/jobs/loggr-system-metrics-agent/config/certs/system_metrics_agent.key

--- a/src/cmd/system-metrics-agent/app/config.go
+++ b/src/cmd/system-metrics-agent/app/config.go
@@ -15,9 +15,10 @@ type Config struct {
 	Index          string        `env:"INDEX, report"`
 	IP             string        `env:"IP, report"`
 
-	DebugPort      uint16 `env:"DEBUG_PORT, report"`
-	MetricPort     uint16 `env:"METRIC_PORT, report, required"`
-	LimitedMetrics bool   `env:"LIMITED_METRICS, report, required"`
+	DebugPort         uint16 `env:"DEBUG_PORT, report"`
+	MetricPort        uint16 `env:"METRIC_PORT, report, required"`
+	LimitedMetrics    bool   `env:"LIMITED_METRICS, report, required"`
+	ClockDriftEnabled bool   `env:"CLOCK_DRIFT_ENABLED, report"`
 
 	CACertPath string `env:"CA_CERT_PATH, required, report"`
 	CertPath   string `env:"CERT_PATH, required, report"`

--- a/src/cmd/system-metrics-agent/app/system_metrics_agent_test.go
+++ b/src/cmd/system-metrics-agent/app/system_metrics_agent_test.go
@@ -164,6 +164,110 @@ var _ = Describe("SystemMetricsAgent", func() {
 		Expect(strings.Count(string(body), "\n")).To(Equal(51))
 	})
 
+	It("omits clock_drift metrics when ClockDriftEnabled is false", func() {
+		// Mirrors what collector.New does when CLOCK_DRIFT_ENABLED=false:
+		// WithoutClockSource() causes ClockDriftEnabled to be false in every
+		// SystemStat, so the Prometheus sender emits no clock_drift_* series.
+		disabledStat := defaultStat
+		disabledStat.ClockDriftEnabled = false
+
+		agent = app.NewSystemMetricsAgent(
+			func() (collector.SystemStat, error) { return disabledStat, nil },
+			app.Config{
+				SampleInterval: time.Millisecond,
+				Deployment:     "some-deployment",
+				Job:            "some-job",
+				Index:          "some-index",
+				IP:             "some-ip",
+				CACertPath:     testCerts.CA(),
+				CertPath:       testCerts.Cert("system-metrics-agent"),
+				KeyPath:        testCerts.Key("system-metrics-agent"),
+			},
+			log.New(GinkgoWriter, "", log.LstdFlags),
+		)
+		go agent.Run()
+		defer agent.Shutdown(context.Background())
+
+		var addr string
+		Eventually(func() int {
+			addr = agent.MetricsAddr()
+			return len(addr)
+		}).ShouldNot(Equal(0))
+
+		client := newTLSClient(
+			testCerts.Cert("system-metrics-agent"),
+			testCerts.Key("system-metrics-agent"),
+			testCerts.CA(),
+			"system-metrics-agent",
+		)
+
+		Eventually(func() string {
+			resp, err := client.Get("https://" + addr + "/metrics")
+			if err != nil {
+				return ""
+			}
+			defer resp.Body.Close() //nolint:errcheck
+			body, _ := io.ReadAll(resp.Body)
+			return string(body)
+		}).ShouldNot(BeEmpty())
+
+		resp, err := client.Get("https://" + addr + "/metrics")
+		Expect(err).ToNot(HaveOccurred())
+		body, err := io.ReadAll(resp.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(body)).NotTo(ContainSubstring("clock_drift_"))
+	})
+
+	It("emits clock_drift_collection_errors when ClockDriftEnabled is true", func() {
+		// Mirrors what collector.New does when CLOCK_DRIFT_ENABLED=true:
+		// the clock drift source is active, so even when chronyc fails and
+		// ClockDrift is nil, the collection-errors counter is always emitted.
+		enabledStat := defaultStat
+		enabledStat.ClockDriftEnabled = true
+		enabledStat.ClockDrift = nil       // no successful collection yet
+		enabledStat.ClockDriftErrorsTotal = 0
+
+		agent = app.NewSystemMetricsAgent(
+			func() (collector.SystemStat, error) { return enabledStat, nil },
+			app.Config{
+				SampleInterval: time.Millisecond,
+				Deployment:     "some-deployment",
+				Job:            "some-job",
+				Index:          "some-index",
+				IP:             "some-ip",
+				CACertPath:     testCerts.CA(),
+				CertPath:       testCerts.Cert("system-metrics-agent"),
+				KeyPath:        testCerts.Key("system-metrics-agent"),
+			},
+			log.New(GinkgoWriter, "", log.LstdFlags),
+		)
+		go agent.Run()
+		defer agent.Shutdown(context.Background())
+
+		var addr string
+		Eventually(func() int {
+			addr = agent.MetricsAddr()
+			return len(addr)
+		}).ShouldNot(Equal(0))
+
+		client := newTLSClient(
+			testCerts.Cert("system-metrics-agent"),
+			testCerts.Key("system-metrics-agent"),
+			testCerts.CA(),
+			"system-metrics-agent",
+		)
+
+		Eventually(func() string {
+			resp, err := client.Get("https://" + addr + "/metrics")
+			if err != nil {
+				return ""
+			}
+			defer resp.Body.Close() //nolint:errcheck
+			body, _ := io.ReadAll(resp.Body)
+			return string(body)
+		}).Should(ContainSubstring("clock_drift_collection_errors"))
+	})
+
 	It("contains default prom labels", func() {
 		go agent.Run()
 		defer agent.Shutdown(context.Background())

--- a/src/cmd/system-metrics-agent/main.go
+++ b/src/cmd/system-metrics-agent/main.go
@@ -16,6 +16,10 @@ func main() {
 
 	cfg := app.LoadConfig()
 
-	c := collector.New(log)
+	var collectorOpts []collector.CollectorOption
+	if !cfg.ClockDriftEnabled {
+		collectorOpts = append(collectorOpts, collector.WithoutClockSource())
+	}
+	c := collector.New(log, collectorOpts...)
 	app.NewSystemMetricsAgent(c.Collect, cfg, log).Run()
 }

--- a/src/integration/system-metrics-agent_test.go
+++ b/src/integration/system-metrics-agent_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 
 	"code.cloudfoundry.org/system-metrics-release/src/internal/testhelper"
@@ -18,13 +19,15 @@ import (
 
 var _ = Describe("System Metrics Agent", Ordered, func() {
 	var (
-		tc *testhelper.TestCerts
+		tc                       *testhelper.TestCerts
+		pathToSystemMetricsAgent string
 	)
 
 	BeforeAll(func() {
 		// build agent
 		DeferCleanup(gexec.CleanupBuildArtifacts)
-		pathToSystemMetricsAgent, err := gexec.Build("code.cloudfoundry.org/system-metrics-release/src/cmd/system-metrics-agent")
+		var err error
+		pathToSystemMetricsAgent, err = gexec.Build("code.cloudfoundry.org/system-metrics-release/src/cmd/system-metrics-agent")
 		Expect(err).NotTo(HaveOccurred())
 
 		// setup agent configuration
@@ -154,6 +157,144 @@ system_cpu_idle{deployment="test-deployment",index="test-index",ip="test-ip",job
 
 				return nil
 			}, "5s").Should(Succeed())
+		})
+
+		It("omits clock drift metrics by default (opt-in behavior)", func() {
+			cfg, err := tlsconfig.Build(
+				tlsconfig.WithInternalServiceDefaults(),
+				tlsconfig.WithIdentityFromFile(tc.Cert("system-metrics-agent"), tc.Key("system-metrics-agent")),
+			).Client(
+				tlsconfig.WithAuthorityFromFile(tc.CA()),
+				tlsconfig.WithServerName("system-metrics-agent"),
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			client := &http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: cfg,
+				},
+			}
+
+			Eventually(func() error {
+				resp, err := client.Get("https://localhost:8080/metrics")
+				if err != nil {
+					return err
+				}
+				defer resp.Body.Close() //nolint:errcheck
+
+				if resp.StatusCode != 200 {
+					return fmt.Errorf("expected 200 status code, got %d", resp.StatusCode)
+				}
+
+				b, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return fmt.Errorf("failed to read response body: %w", err)
+				}
+
+				body := string(b)
+				if strings.Contains(body, "clock_drift_") {
+					return fmt.Errorf("expected no clock_drift_ metrics, but found them in response")
+				}
+
+				return nil
+			}, "10s").Should(Succeed())
+		})
+	})
+
+	Describe("when CLOCK_DRIFT_ENABLED is true", func() {
+		var (
+			fakeBinDir string
+			session    *gexec.Session
+		)
+
+		BeforeEach(func() {
+			if runtime.GOOS == "windows" {
+				Skip("clock drift monitoring is not supported on Windows")
+			}
+		})
+
+		BeforeAll(func() {
+			if runtime.GOOS == "windows" {
+				return // BeforeAll runs before BeforeEach, so we must return early here too
+			}
+
+			// Create a fake chronyc executable so the agent's exec.LookPath succeeds
+			var err error
+			fakeBinDir, err = os.MkdirTemp("", "fake-bin")
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(os.RemoveAll, fakeBinDir)
+
+			fakeChronycPath := fakeBinDir + "/chronyc"
+			err = os.WriteFile(fakeChronycPath, []byte("#!/bin/sh\nexit 1\n"), 0755)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Start a new agent with CLOCK_DRIFT_ENABLED=true and the fake chronyc in PATH
+			cmd := exec.Command(pathToSystemMetricsAgent)
+			cmd.Env = append(os.Environ(),
+				"PATH="+fakeBinDir+":"+os.Getenv("PATH"),
+				"CLOCK_DRIFT_ENABLED=true",
+				"METRIC_PORT=8081", // Use a different port to avoid conflict with the default agent
+				"LIMITED_METRICS=false",
+				"SAMPLE_INTERVAL=1s",
+				"DEPLOYMENT=test-deployment",
+				"JOB=test-job",
+				"INDEX=test-index",
+				"IP=test-ip",
+				"CA_CERT_PATH="+tc.CA(),
+				"CERT_PATH="+tc.Cert("system-metrics-agent"),
+				"KEY_PATH="+tc.Key("system-metrics-agent"),
+			)
+
+			session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterAll(func() {
+			if session != nil {
+				session.Kill().Wait()
+			}
+		})
+
+		It("emits clock drift metrics", func() {
+			cfg, err := tlsconfig.Build(
+				tlsconfig.WithInternalServiceDefaults(),
+				tlsconfig.WithIdentityFromFile(tc.Cert("system-metrics-agent"), tc.Key("system-metrics-agent")),
+			).Client(
+				tlsconfig.WithAuthorityFromFile(tc.CA()),
+				tlsconfig.WithServerName("system-metrics-agent"),
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			client := &http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: cfg,
+				},
+			}
+
+			Eventually(func() error {
+				resp, err := client.Get("https://localhost:8081/metrics")
+				if err != nil {
+					return err
+				}
+				defer resp.Body.Close() //nolint:errcheck
+
+				if resp.StatusCode != 200 {
+					return fmt.Errorf("expected 200 status code, got %d", resp.StatusCode)
+				}
+
+				b, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return fmt.Errorf("failed to read response body: %w", err)
+				}
+
+				body := string(b)
+				// Because our fake chronyc exits with 1, we expect the collection errors counter to be present
+				if !strings.Contains(body, "clock_drift_collection_errors") {
+					return fmt.Errorf("expected clock_drift_collection_errors metric, but not found in response")
+				}
+
+				return nil
+			}, "10s").Should(Succeed())
 		})
 	})
 })

--- a/src/pkg/collector/clockdrift/chronyc.go
+++ b/src/pkg/collector/clockdrift/chronyc.go
@@ -2,6 +2,7 @@ package clockdrift
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -321,18 +322,67 @@ func missingRequiredKeys(raw map[string]string) []string {
 }
 
 // parseReferenceID splits a chronyc reference value of the form
-// `<hex-id> (<host>)` into (id, host). When the host segment is missing or
-// empty the host return is empty and parentheses never leak into label
-// values.
+// `<hex-id> (<host>)` into (id, host), decoding the hexadecimal <hex-id> into
+// an IP address or an ASCII string if it is a stratum 1 source. When the host
+// segment is missing or empty the host return is empty and parentheses never
+// leak into label values.
 func parseReferenceID(v string) (string, string) {
 	v = strings.TrimSpace(v)
 	if m := refIDPattern.FindStringSubmatch(v); m != nil {
-		return m[1], strings.TrimSpace(m[2])
+		return decodeReferenceID(m[1]), strings.TrimSpace(m[2])
 	}
 	// Strip any stray parens (e.g., `7F7F0101 ()` when chrony has no peer)
 	// rather than letting them propagate into Prometheus label values.
 	v = strings.TrimRight(strings.TrimSpace(strings.TrimSuffix(v, "()")), " ")
-	return v, ""
+	return decodeReferenceID(v), ""
+}
+
+// decodeReferenceID converts a 32-bit hexadecimal reference ID string
+// to either a human-readable ASCII string (if it's a stratum 1 reference
+// clock like GPS/PPS) or an IPv4 address. If the input is not a valid
+// 8-character hex string, it is returned unmodified.
+func decodeReferenceID(hexStr string) string {
+	hexStr = strings.TrimSpace(hexStr)
+	if len(hexStr) != 8 {
+		return hexStr
+	}
+	bytes, err := hex.DecodeString(hexStr)
+	if err != nil {
+		return hexStr
+	}
+
+	// Check if all bytes are printable ASCII or trailing null padding.
+	// This helps identify Stratum 1 reference clocks (e.g., GPS, PPS, ACTS, LOCL).
+	isASCII := true
+	for i, b := range bytes {
+		if b == 0 {
+			// Zero padding must extend to the end of the 4-byte block
+			for j := i; j < len(bytes); j++ {
+				if bytes[j] != 0 {
+					isASCII = false
+					break
+				}
+			}
+			break
+		}
+		// Printable ASCII characters are 32 (' ') through 126 ('~')
+		if b < 32 || b > 126 {
+			isASCII = false
+			break
+		}
+	}
+
+	if isASCII {
+		s := string(bytes)
+		s = strings.TrimRight(s, "\x00")
+		s = strings.TrimSpace(s)
+		if len(s) > 0 {
+			return s
+		}
+	}
+
+	// Otherwise, format as an IPv4 address
+	return fmt.Sprintf("%d.%d.%d.%d", bytes[0], bytes[1], bytes[2], bytes[3])
 }
 
 func firstLine(s string) string {

--- a/src/pkg/collector/clockdrift/chronyc.go
+++ b/src/pkg/collector/clockdrift/chronyc.go
@@ -1,0 +1,432 @@
+package clockdrift
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"math"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// chronyc field-name keys exactly as printed by `chronyc tracking`. Promoted
+// to constants so a typo is a compile error rather than a silently-zeroed
+// metric.
+const (
+	keyReferenceID    = "Reference ID"
+	keyStratum        = "Stratum"
+	keyRefTimeUTC     = "Ref time (UTC)"
+	keySystemTime     = "System time"
+	keyLastOffset     = "Last offset"
+	keyRMSOffset      = "RMS offset"
+	keyFrequency      = "Frequency"
+	keyResidualFreq   = "Residual freq"
+	keySkew           = "Skew"
+	keyRootDelay      = "Root delay"
+	keyRootDispersion = "Root dispersion"
+	keyUpdateInterval = "Update interval"
+	keyLeapStatus     = "Leap status"
+)
+
+// requiredKeys are the minimum chronyc fields that MUST appear in valid
+// tracking output. Their absence indicates either a chronyc error response
+// (e.g., "506 Cannot talk to daemon") or a parser regression after a chrony
+// version bump; either way, returning a fatal error is preferable to
+// emitting a fully-zeroed snapshot that an auditor would read as healthy.
+var requiredKeys = []string{keyReferenceID, keyStratum, keyLeapStatus}
+
+// chronyErrorPrefixes are line prefixes that chronyc uses to report client
+// errors. These never appear in successful `tracking` output so detecting
+// any of them lets us fail fast with a useful diagnostic.
+var chronyErrorPrefixes = []string{"506 ", "501 ", "Error :", "Could not"}
+
+// DefaultCacheTTL is how long ChronyBackend reuses the most recent successful
+// snapshot before invoking chronyc again. Compliance dashboards stay fresh
+// while we avoid forking once per system-metrics tick (typically 15s).
+const DefaultCacheTTL = 0 //5 * time.Minute
+
+// ChronyBackend implements TimeSource by executing `chronyc tracking`.
+//
+// Behavior:
+//   - exec is wrapped in the caller-supplied context (5s timeout in
+//     production) so a wedged chronyd cannot stall the metrics agent.
+//   - Locale and timezone are pinned via LANG=C, LC_ALL=C, TZ=UTC so a
+//     reconfigured stemcell cannot accidentally rename chrony's field keys
+//     out from under the parser.
+//   - Successful results are cached for cacheTTL to avoid forking chronyc
+//     more often than the audit cadence demands.
+//
+// Linux is the only currently-supported platform. Azure Linux VMs use chrony
+// with a PTP reference clock (/dev/ptp_hyperv) and produce identical
+// `chronyc tracking` output, so no Azure-specific code is required.
+type ChronyBackend struct {
+	runner   func(ctx context.Context) (string, error)
+	logger   *log.Logger
+	cacheTTL time.Duration
+
+	mu         sync.Mutex
+	cachedData *TimeSyncData
+	cachedAt   time.Time
+}
+
+// ChronyOption configures a ChronyBackend at construction time.
+type ChronyOption func(*ChronyBackend)
+
+// WithCmdRunner overrides the function used to execute `chronyc tracking`.
+// Tests inject a fake to return canned output without forking a process.
+func WithCmdRunner(r func(ctx context.Context) (string, error)) ChronyOption {
+	return func(c *ChronyBackend) {
+		c.runner = r
+	}
+}
+
+// WithLogger sets the logger used for non-fatal parse warnings. If unset,
+// warnings are silently discarded so the package never spams the agent log.
+func WithLogger(l *log.Logger) ChronyOption {
+	return func(c *ChronyBackend) {
+		c.logger = l
+	}
+}
+
+// WithCacheTTL overrides the duration for which a successful snapshot is
+// reused. A non-positive value disables caching and forces every Collect
+// call to invoke chronyc.
+func WithCacheTTL(d time.Duration) ChronyOption {
+	return func(c *ChronyBackend) {
+		c.cacheTTL = d
+	}
+}
+
+// NewChronyBackend constructs a ChronyBackend with sensible defaults that
+// can be selectively overridden via options.
+func NewChronyBackend(opts ...ChronyOption) *ChronyBackend {
+	b := &ChronyBackend{
+		runner:   execChronyc,
+		logger:   log.New(io.Discard, "", 0),
+		cacheTTL: DefaultCacheTTL,
+	}
+	for _, o := range opts {
+		o(b)
+	}
+	if b.runner == nil {
+		b.runner = execChronyc
+	}
+	if b.logger == nil {
+		b.logger = log.New(io.Discard, "", 0)
+	}
+	return b
+}
+
+// Name returns the backend identifier ("chrony").
+func (c *ChronyBackend) Name() string { return BackendChrony }
+
+// Collect returns the latest TimeSyncData, honoring the supplied context's
+// deadline. The result may come from an in-memory cache if the previous call
+// succeeded within cacheTTL.
+func (c *ChronyBackend) Collect(ctx context.Context) (*TimeSyncData, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	if cached := c.cached(); cached != nil {
+		return cached, nil
+	}
+
+	output, err := c.runner(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("chronyc tracking: %w", err)
+	}
+
+	data, err := parseChronyToTimeSyncData(output, c.logger)
+	if err != nil {
+		return nil, err
+	}
+
+	c.store(data)
+	return data, nil
+}
+
+func (c *ChronyBackend) cached() *TimeSyncData {
+	if c.cacheTTL <= 0 {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.cachedData == nil || time.Since(c.cachedAt) > c.cacheTTL {
+		return nil
+	}
+	return c.cachedData
+}
+
+func (c *ChronyBackend) store(data *TimeSyncData) {
+	if c.cacheTTL <= 0 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.cachedData = data
+	c.cachedAt = time.Now()
+}
+
+// execChronyc runs `chronyc tracking` under the supplied context, with the
+// process environment trimmed to a known-good locale and timezone so chrony
+// produces field keys in the format the parser expects.
+func execChronyc(ctx context.Context) (string, error) {
+	cmd := exec.CommandContext(ctx, "chronyc", "tracking")
+	// LANG=C and LC_ALL=C are load-bearing: chrony's field keys ("Reference
+	// ID", "Leap status", ...) are localizable via the LC_TIME locale, and a
+	// reconfigured stemcell could otherwise rename them out from under the
+	// parser. TZ=UTC is belt-and-suspenders only -- chronyc tracking already
+	// formats "Ref time (UTC)" via gmtime_r regardless of TZ.
+	cmd.Env = append(os.Environ(), "LANG=C", "LC_ALL=C", "TZ=UTC")
+
+	out, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return "", fmt.Errorf("chronyc exited %d: %s", exitErr.ExitCode(), strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return "", fmt.Errorf("failed to run chronyc: %w", err)
+	}
+	return string(out), nil
+}
+
+// refIDPattern matches `<hex-id> (<host>)`. The host group is permissive
+// because chrony emits IPv4, IPv6, and DNS hostnames.
+var refIDPattern = regexp.MustCompile(`^([0-9A-Fa-f]+)\s*\((.*)\)$`)
+
+// parseChronyToTimeSyncData parses raw `chronyc tracking` output into typed
+// fields. Field-level parse failures populate math.NaN() (for floats) or nil
+// (for *int / *float64) so the sender can suppress the corresponding gauges.
+// Whole-output failures (chronyc error response, missing required keys)
+// return an error so the caller can surface them via the error counter.
+func parseChronyToTimeSyncData(output string, logger *log.Logger) (*TimeSyncData, error) {
+	if logger == nil {
+		logger = log.New(io.Discard, "", 0)
+	}
+
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		return nil, errors.New("empty chronyc tracking output")
+	}
+
+	for _, prefix := range chronyErrorPrefixes {
+		if strings.HasPrefix(trimmed, prefix) {
+			return nil, fmt.Errorf("chronyc reported an error: %s", firstLine(trimmed))
+		}
+	}
+
+	raw := make(map[string]string)
+	for _, line := range strings.Split(trimmed, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		key, value, ok := splitKeyValue(line)
+		if !ok {
+			continue
+		}
+		raw[key] = value
+	}
+
+	if len(raw) == 0 {
+		return nil, errors.New("no valid key-value pairs found in chronyc output")
+	}
+
+	missing := missingRequiredKeys(raw)
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("chronyc output missing required keys: %s", strings.Join(missing, ", "))
+	}
+
+	data := &TimeSyncData{
+		SystemTimeOffsetSec: math.NaN(),
+		LastOffsetSec:       math.NaN(),
+		RMSOffsetSec:        math.NaN(),
+		FrequencyPPM:        math.NaN(),
+		ResidualFreqPPM:     math.NaN(),
+		SkewPPM:             math.NaN(),
+		RootDelaySec:        math.NaN(),
+		RootDispersionSec:   math.NaN(),
+		UpdateIntervalSec:   math.NaN(),
+		SystemTimeDirection: DirectionUnknown,
+		FrequencyDirection:  DirectionUnknown,
+	}
+
+	if v, ok := raw[keyReferenceID]; ok {
+		data.ReferenceID, data.ReferenceHost = parseReferenceID(v)
+	}
+
+	if v, ok := raw[keyStratum]; ok {
+		if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil {
+			data.Stratum = &n
+		} else {
+			logger.Printf("clockdrift: parse Stratum %q: %v", v, err)
+		}
+	}
+
+	data.RefTimeUTC = raw[keyRefTimeUTC]
+	if ts, ok := parseRefTime(data.RefTimeUTC); ok {
+		data.RefTimeUnixSec = &ts
+	} else if data.RefTimeUTC != "" {
+		logger.Printf("clockdrift: parse RefTimeUTC %q failed", data.RefTimeUTC)
+	}
+
+	data.LeapStatus = ParseLeapStatus(raw[keyLeapStatus])
+
+	data.SystemTimeOffsetSec, data.SystemTimeDirection = parseOffsetWithDirection(raw[keySystemTime], logger, keySystemTime)
+	data.LastOffsetSec = parseSeconds(raw[keyLastOffset], logger, keyLastOffset)
+	data.RMSOffsetSec = parseSeconds(raw[keyRMSOffset], logger, keyRMSOffset)
+	data.FrequencyPPM, data.FrequencyDirection = parsePPMWithDirection(raw[keyFrequency], logger, keyFrequency)
+	data.ResidualFreqPPM = parsePPM(raw[keyResidualFreq], logger, keyResidualFreq)
+	data.SkewPPM = parsePPM(raw[keySkew], logger, keySkew)
+	data.RootDelaySec = parseSeconds(raw[keyRootDelay], logger, keyRootDelay)
+	data.RootDispersionSec = parseSeconds(raw[keyRootDispersion], logger, keyRootDispersion)
+	data.UpdateIntervalSec = parseSeconds(raw[keyUpdateInterval], logger, keyUpdateInterval)
+
+	return data, nil
+}
+
+// splitKeyValue cuts a chronyc tracking line into (key, value) at the first
+// colon. Splitting on the first colon (rather than the literal " : "
+// separator) tolerates column-alignment changes and any quirks in chrony's
+// padding logic.
+func splitKeyValue(line string) (string, string, bool) {
+	idx := strings.Index(line, ":")
+	if idx < 0 {
+		return "", "", false
+	}
+	key := strings.TrimSpace(line[:idx])
+	value := strings.TrimSpace(line[idx+1:])
+	if key == "" {
+		return "", "", false
+	}
+	return key, value, true
+}
+
+func missingRequiredKeys(raw map[string]string) []string {
+	var missing []string
+	for _, k := range requiredKeys {
+		if _, ok := raw[k]; !ok {
+			missing = append(missing, k)
+		}
+	}
+	return missing
+}
+
+// parseReferenceID splits a chronyc reference value of the form
+// `<hex-id> (<host>)` into (id, host). When the host segment is missing or
+// empty the host return is empty and parentheses never leak into label
+// values.
+func parseReferenceID(v string) (string, string) {
+	v = strings.TrimSpace(v)
+	if m := refIDPattern.FindStringSubmatch(v); m != nil {
+		return m[1], strings.TrimSpace(m[2])
+	}
+	// Strip any stray parens (e.g., `7F7F0101 ()` when chrony has no peer)
+	// rather than letting them propagate into Prometheus label values.
+	v = strings.TrimRight(strings.TrimSpace(strings.TrimSuffix(v, "()")), " ")
+	return v, ""
+}
+
+func firstLine(s string) string {
+	if i := strings.Index(s, "\n"); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return strings.TrimSpace(s)
+}
+
+func parseSeconds(s string, logger *log.Logger, fieldName string) float64 {
+	fields := strings.Fields(s)
+	if len(fields) == 0 {
+		return math.NaN()
+	}
+	v, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		logger.Printf("clockdrift: parse %s %q: %v", fieldName, s, err)
+		return math.NaN()
+	}
+	return v
+}
+
+func parseOffsetWithDirection(s string, logger *log.Logger, fieldName string) (float64, TimeDirection) {
+	fields := strings.Fields(s)
+	if len(fields) == 0 {
+		return math.NaN(), DirectionUnknown
+	}
+	v, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		logger.Printf("clockdrift: parse %s %q: %v", fieldName, s, err)
+		return math.NaN(), DirectionUnknown
+	}
+	if len(fields) < 3 {
+		return v, DirectionUnknown
+	}
+	dir := ParseTimeDirection(fields[2])
+	if dir == DirectionSlow {
+		v = -v
+	}
+	return v, dir
+}
+
+func parsePPMWithDirection(s string, logger *log.Logger, fieldName string) (float64, TimeDirection) {
+	fields := strings.Fields(s)
+	if len(fields) == 0 {
+		return math.NaN(), DirectionUnknown
+	}
+	v, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		logger.Printf("clockdrift: parse %s %q: %v", fieldName, s, err)
+		return math.NaN(), DirectionUnknown
+	}
+	if len(fields) < 3 {
+		return v, DirectionUnknown
+	}
+	dir := ParseTimeDirection(fields[2])
+	if dir == DirectionSlow {
+		v = -v
+	}
+	return v, dir
+}
+
+func parsePPM(s string, logger *log.Logger, fieldName string) float64 {
+	fields := strings.Fields(s)
+	if len(fields) == 0 {
+		return math.NaN()
+	}
+	v, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		logger.Printf("clockdrift: parse %s %q: %v", fieldName, s, err)
+		return math.NaN()
+	}
+	return v
+}
+
+// parseRefTime converts chronyc's "Ref time (UTC)" value to a Unix epoch
+// timestamp. The layout uses `_2` (space-padded day) so values like
+// "Tue Dec  2 21:14:33 2025" parse correctly. The bool return distinguishes
+// "successfully parsed" from "missing or unparseable" so the caller can
+// represent the latter as a nil pointer rather than the misleading 1970
+// epoch.
+func parseRefTime(s string) (float64, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, false
+	}
+	layouts := []string{
+		"Mon Jan _2 15:04:05 2006",
+		"Mon Jan 02 15:04:05 2006",
+	}
+	for _, layout := range layouts {
+		if t, err := time.ParseInLocation(layout, s, time.UTC); err == nil {
+			return float64(t.Unix()), true
+		}
+	}
+	return 0, false
+}

--- a/src/pkg/collector/clockdrift/chronyc.go
+++ b/src/pkg/collector/clockdrift/chronyc.go
@@ -60,10 +60,6 @@ const DefaultCacheTTL = 0
 //     out from under the parser.
 //   - Successful results are cached for cacheTTL to avoid forking chronyc
 //     more often than the audit cadence demands.
-//
-// Linux is the only currently-supported platform. Azure Linux VMs use chrony
-// with a PTP reference clock (/dev/ptp_hyperv) and produce identical
-// `chronyc tracking` output, so no Azure-specific code is required.
 type ChronyBackend struct {
 	runner   func(ctx context.Context) (string, error)
 	logger   *log.Logger

--- a/src/pkg/collector/clockdrift/chronyc.go
+++ b/src/pkg/collector/clockdrift/chronyc.go
@@ -26,13 +26,8 @@ const (
 	keyRefTimeUTC     = "Ref time (UTC)"
 	keySystemTime     = "System time"
 	keyLastOffset     = "Last offset"
-	keyRMSOffset      = "RMS offset"
 	keyFrequency      = "Frequency"
-	keyResidualFreq   = "Residual freq"
-	keySkew           = "Skew"
 	keyRootDelay      = "Root delay"
-	keyRootDispersion = "Root dispersion"
-	keyUpdateInterval = "Update interval"
 	keyLeapStatus     = "Leap status"
 )
 
@@ -251,13 +246,8 @@ func parseChronyToTimeSyncData(output string, logger *log.Logger) (*TimeSyncData
 	data := &TimeSyncData{
 		SystemTimeOffsetSec: math.NaN(),
 		LastOffsetSec:       math.NaN(),
-		RMSOffsetSec:        math.NaN(),
 		FrequencyPPM:        math.NaN(),
-		ResidualFreqPPM:     math.NaN(),
-		SkewPPM:             math.NaN(),
 		RootDelaySec:        math.NaN(),
-		RootDispersionSec:   math.NaN(),
-		UpdateIntervalSec:   math.NaN(),
 		SystemTimeDirection: DirectionUnknown,
 		FrequencyDirection:  DirectionUnknown,
 	}
@@ -275,23 +265,13 @@ func parseChronyToTimeSyncData(output string, logger *log.Logger) (*TimeSyncData
 	}
 
 	data.RefTimeUTC = raw[keyRefTimeUTC]
-	if ts, ok := parseRefTime(data.RefTimeUTC); ok {
-		data.RefTimeUnixSec = &ts
-	} else if data.RefTimeUTC != "" {
-		logger.Printf("clockdrift: parse RefTimeUTC %q failed", data.RefTimeUTC)
-	}
 
 	data.LeapStatus = ParseLeapStatus(raw[keyLeapStatus])
 
 	data.SystemTimeOffsetSec, data.SystemTimeDirection = parseOffsetWithDirection(raw[keySystemTime], logger, keySystemTime)
 	data.LastOffsetSec = parseSeconds(raw[keyLastOffset], logger, keyLastOffset)
-	data.RMSOffsetSec = parseSeconds(raw[keyRMSOffset], logger, keyRMSOffset)
 	data.FrequencyPPM, data.FrequencyDirection = parsePPMWithDirection(raw[keyFrequency], logger, keyFrequency)
-	data.ResidualFreqPPM = parsePPM(raw[keyResidualFreq], logger, keyResidualFreq)
-	data.SkewPPM = parsePPM(raw[keySkew], logger, keySkew)
 	data.RootDelaySec = parseSeconds(raw[keyRootDelay], logger, keyRootDelay)
-	data.RootDispersionSec = parseSeconds(raw[keyRootDispersion], logger, keyRootDispersion)
-	data.UpdateIntervalSec = parseSeconds(raw[keyUpdateInterval], logger, keyUpdateInterval)
 
 	return data, nil
 }
@@ -445,40 +425,4 @@ func parsePPMWithDirection(s string, logger *log.Logger, fieldName string) (floa
 		v = -v
 	}
 	return v, dir
-}
-
-func parsePPM(s string, logger *log.Logger, fieldName string) float64 {
-	fields := strings.Fields(s)
-	if len(fields) == 0 {
-		return math.NaN()
-	}
-	v, err := strconv.ParseFloat(fields[0], 64)
-	if err != nil {
-		logger.Printf("clockdrift: parse %s %q: %v", fieldName, s, err)
-		return math.NaN()
-	}
-	return v
-}
-
-// parseRefTime converts chronyc's "Ref time (UTC)" value to a Unix epoch
-// timestamp. The layout uses `_2` (space-padded day) so values like
-// "Tue Dec  2 21:14:33 2025" parse correctly. The bool return distinguishes
-// "successfully parsed" from "missing or unparseable" so the caller can
-// represent the latter as a nil pointer rather than the misleading 1970
-// epoch.
-func parseRefTime(s string) (float64, bool) {
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return 0, false
-	}
-	layouts := []string{
-		"Mon Jan _2 15:04:05 2006",
-		"Mon Jan 02 15:04:05 2006",
-	}
-	for _, layout := range layouts {
-		if t, err := time.ParseInLocation(layout, s, time.UTC); err == nil {
-			return float64(t.Unix()), true
-		}
-	}
-	return 0, false
 }

--- a/src/pkg/collector/clockdrift/chronyc.go
+++ b/src/pkg/collector/clockdrift/chronyc.go
@@ -48,10 +48,12 @@ var requiredKeys = []string{keyReferenceID, keyStratum, keyLeapStatus}
 // any of them lets us fail fast with a useful diagnostic.
 var chronyErrorPrefixes = []string{"506 ", "501 ", "Error :", "Could not"}
 
-// DefaultCacheTTL is how long ChronyBackend reuses the most recent successful
-// snapshot before invoking chronyc again. Compliance dashboards stay fresh
-// while we avoid forking once per system-metrics tick (typically 15s).
-const DefaultCacheTTL = 0 //5 * time.Minute
+// DefaultCacheTTL controls result reuse between collection ticks. Zero
+// disables caching: chronyc is invoked on every tick (typically every 15s),
+// keeping clock drift metrics at the same cadence as all other system metrics
+// and ensuring a lost-sync event surfaces within one tick rather than up to
+// five minutes later.
+const DefaultCacheTTL = 0
 
 // ChronyBackend implements TimeSource by executing `chronyc tracking`.
 //

--- a/src/pkg/collector/clockdrift/chronyc_test.go
+++ b/src/pkg/collector/clockdrift/chronyc_test.go
@@ -138,10 +138,12 @@ func TestParseReferenceID(t *testing.T) {
 		wantID   string
 		wantHost string
 	}{
-		{"id and host", "49B9B6D1 (73.185.182.209)", "49B9B6D1", "73.185.182.209"},
-		{"id only no parens", "7F7F0101", "7F7F0101", ""},
-		{"id with empty parens", "00000000 ()", "00000000", ""},
-		{"hostname inside parens", "ABCDEF01 (time.example.com)", "ABCDEF01", "time.example.com"},
+		{"id and host", "49B9B6D1 (73.185.182.209)", "73.185.182.209", "73.185.182.209"},
+		{"id only no parens", "7F7F0101", "127.127.1.1", ""},
+		{"id with empty parens", "00000000 ()", "0.0.0.0", ""},
+		{"hostname inside parens", "ABCDEF01 (time.example.com)", "171.205.239.1", "time.example.com"},
+		{"stratum 1 GPS ASCII", "47505300 (GPS)", "GPS", "GPS"},
+		{"stratum 1 LOCL ASCII", "4c4f434c (LOCL)", "LOCL", "LOCL"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -174,8 +176,8 @@ Leap status     : Normal`
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if data.ReferenceID != "49B9B6D1" {
-		t.Errorf("ReferenceID: got %q, want %q", data.ReferenceID, "49B9B6D1")
+	if data.ReferenceID != "73.185.182.209" {
+		t.Errorf("ReferenceID: got %q, want %q", data.ReferenceID, "73.185.182.209")
 	}
 	if data.ReferenceHost != "73.185.182.209" {
 		t.Errorf("ReferenceHost: got %q, want %q", data.ReferenceHost, "73.185.182.209")
@@ -310,8 +312,8 @@ Leap status     : Normal`
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if data.ReferenceID != "49B9B6D1" {
-		t.Errorf("ReferenceID: got %q, want %q", data.ReferenceID, "49B9B6D1")
+	if data.ReferenceID != "73.185.182.209" {
+		t.Errorf("ReferenceID: got %q, want %q", data.ReferenceID, "73.185.182.209")
 	}
 	if b.Name() != BackendChrony {
 		t.Errorf("Name() = %q, want %q", b.Name(), BackendChrony)

--- a/src/pkg/collector/clockdrift/chronyc_test.go
+++ b/src/pkg/collector/clockdrift/chronyc_test.go
@@ -1,0 +1,445 @@
+package clockdrift
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log"
+	"math"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestParseTimeDirection(t *testing.T) {
+	tests := []struct {
+		input string
+		want  TimeDirection
+	}{
+		{"slow", DirectionSlow},
+		{"fast", DirectionFast},
+		{"", DirectionUnknown},
+		{"behind", DirectionUnknown},
+		{"SLOW", DirectionUnknown},
+	}
+	for _, tc := range tests {
+		got := ParseTimeDirection(tc.input)
+		if got != tc.want {
+			t.Errorf("ParseTimeDirection(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestParseOffsetWithDirection(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantVal float64
+		wantDir TimeDirection
+	}{
+		{"slow flips sign", "0.000314477 seconds slow of NTP time", -0.000314477, DirectionSlow},
+		{"fast keeps sign", "0.000314477 seconds fast of NTP time", 0.000314477, DirectionFast},
+		{"missing direction", "0.000314477 seconds", 0.000314477, DirectionUnknown},
+		{"non-numeric value", "invalid", math.NaN(), DirectionUnknown},
+		{"empty string", "", math.NaN(), DirectionUnknown},
+	}
+	logger := log.New(io.Discard, "", 0)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotVal, gotDir := parseOffsetWithDirection(tc.input, logger, "test")
+			if !floatEquals(gotVal, tc.wantVal) || gotDir != tc.wantDir {
+				t.Errorf("parseOffsetWithDirection(%q) = (%v, %q), want (%v, %q)",
+					tc.input, gotVal, gotDir, tc.wantVal, tc.wantDir)
+			}
+		})
+	}
+}
+
+func TestParsePPMWithDirection(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantVal float64
+		wantDir TimeDirection
+	}{
+		{"slow flips sign", "10.246 ppm slow", -10.246, DirectionSlow},
+		{"fast keeps sign", "10.246 ppm fast", 10.246, DirectionFast},
+		{"missing direction", "10.246 ppm", 10.246, DirectionUnknown},
+		{"non-numeric value", "junk", math.NaN(), DirectionUnknown},
+	}
+	logger := log.New(io.Discard, "", 0)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotVal, gotDir := parsePPMWithDirection(tc.input, logger, "test")
+			if !floatEquals(gotVal, tc.wantVal) || gotDir != tc.wantDir {
+				t.Errorf("parsePPMWithDirection(%q) = (%v, %q), want (%v, %q)",
+					tc.input, gotVal, gotDir, tc.wantVal, tc.wantDir)
+			}
+		})
+	}
+}
+
+func TestParseRefTime(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantTS  float64
+		wantOK  bool
+	}{
+		{"zero-padded day", "Tue Dec 02 21:14:33 2025", 1764710073, true},
+		{"space-padded single-digit day", "Tue Dec  2 21:14:33 2025", 1764710073, true},
+		{"empty string", "", 0, false},
+		{"junk", "not-a-date", 0, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotTS, gotOK := parseRefTime(tc.input)
+			if gotOK != tc.wantOK {
+				t.Fatalf("parseRefTime(%q) ok = %v, want %v", tc.input, gotOK, tc.wantOK)
+			}
+			if gotOK && gotTS != tc.wantTS {
+				t.Errorf("parseRefTime(%q) = %v, want %v", tc.input, gotTS, tc.wantTS)
+			}
+		})
+	}
+}
+
+func TestParseLeapStatus(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  LeapStatus
+	}{
+		{"normal", "Normal", LeapNormal},
+		{"insert", "Insert second", LeapInsertSecond},
+		{"delete", "Delete second", LeapDeleteSecond},
+		{"british unsync", "Not synchronised", LeapNotSynchronised},
+		{"american unsync", "Not synchronized", LeapNotSynchronised},
+		{"case insensitive", "NORMAL", LeapNormal},
+		{"surrounding whitespace", "  Insert second  ", LeapInsertSecond},
+		{"empty", "", LeapUnknown},
+		{"unknown literal", "Something else", LeapUnknown},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseLeapStatus(tc.input)
+			if got != tc.want {
+				t.Errorf("ParseLeapStatus(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseReferenceID(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantID   string
+		wantHost string
+	}{
+		{"id and host", "49B9B6D1 (73.185.182.209)", "49B9B6D1", "73.185.182.209"},
+		{"id only no parens", "7F7F0101", "7F7F0101", ""},
+		{"id with empty parens", "00000000 ()", "00000000", ""},
+		{"hostname inside parens", "ABCDEF01 (time.example.com)", "ABCDEF01", "time.example.com"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotID, gotHost := parseReferenceID(tc.input)
+			if gotID != tc.wantID || gotHost != tc.wantHost {
+				t.Errorf("parseReferenceID(%q) = (%q, %q), want (%q, %q)",
+					tc.input, gotID, gotHost, tc.wantID, tc.wantHost)
+			}
+		})
+	}
+}
+
+func TestParseChronyToTimeSyncData_HappyPath(t *testing.T) {
+	sample := `Reference ID    : 49B9B6D1 (73.185.182.209)
+Stratum         : 4
+Ref time (UTC)  : Tue Dec 02 21:14:33 2025
+System time     : 0.000314477 seconds slow of NTP time
+Last offset     : -0.000364028 seconds
+RMS offset      : 0.000758087 seconds
+Frequency       : 10.246 ppm slow
+Residual freq   : -0.003 ppm
+Skew            : 0.146 ppm
+Root delay      : 0.070813648 seconds
+Root dispersion : 0.011881540 seconds
+Update interval : 2073.3 seconds
+Leap status     : Normal`
+
+	data, err := parseChronyToTimeSyncData(sample, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if data.ReferenceID != "49B9B6D1" {
+		t.Errorf("ReferenceID: got %q, want %q", data.ReferenceID, "49B9B6D1")
+	}
+	if data.ReferenceHost != "73.185.182.209" {
+		t.Errorf("ReferenceHost: got %q, want %q", data.ReferenceHost, "73.185.182.209")
+	}
+	if data.Stratum == nil || *data.Stratum != 4 {
+		t.Errorf("Stratum: got %v, want pointer to 4", data.Stratum)
+	}
+	if data.SystemTimeOffsetSec != -0.000314477 {
+		t.Errorf("SystemTimeOffsetSec: got %v, want %v", data.SystemTimeOffsetSec, -0.000314477)
+	}
+	if data.FrequencyPPM != -10.246 {
+		t.Errorf("FrequencyPPM: got %v, want %v", data.FrequencyPPM, -10.246)
+	}
+	if data.UpdateIntervalSec != 2073.3 {
+		t.Errorf("UpdateIntervalSec: got %v, want %v", data.UpdateIntervalSec, 2073.3)
+	}
+	if data.RefTimeUnixSec == nil || *data.RefTimeUnixSec != 1764710073 {
+		t.Errorf("RefTimeUnixSec: got %v, want pointer to 1764710073", data.RefTimeUnixSec)
+	}
+	if data.LeapStatus != LeapNormal {
+		t.Errorf("LeapStatus: got %q, want %q", data.LeapStatus, LeapNormal)
+	}
+}
+
+func TestParseChronyToTimeSyncData_FatalErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantError string
+	}{
+		{"empty input", "", "empty"},
+		{"only whitespace", "   \n\t\n", "empty"},
+		{"chronyc 506 error", "506 Cannot talk to daemon", "chronyc reported an error"},
+		{"chronyc 501 error", "501 Not authorised", "chronyc reported an error"},
+		{"missing required keys", "Unrelated  : value\nOther    : value", "missing required keys"},
+		{"only one required key", "Reference ID  : DEADBEEF", "missing required keys"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseChronyToTimeSyncData(tc.input, nil)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantError)
+			}
+			if !strings.Contains(err.Error(), tc.wantError) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.wantError)
+			}
+		})
+	}
+}
+
+func TestParseChronyToTimeSyncData_FieldLevelParseFailures(t *testing.T) {
+	// Required keys present but several values are unparseable; we expect a
+	// successful parse with NaN/nil sentinels rather than fake zeros.
+	input := `Reference ID    : 49B9B6D1 (73.185.182.209)
+Stratum         : not-a-number
+Ref time (UTC)  : garbage
+System time     : also-garbage
+Last offset     : 0.5 seconds
+Leap status     : Normal`
+
+	data, err := parseChronyToTimeSyncData(input, log.New(io.Discard, "", 0))
+	if err != nil {
+		t.Fatalf("unexpected fatal error: %v", err)
+	}
+	if data.Stratum != nil {
+		t.Errorf("Stratum: got %v, want nil for unparseable input", data.Stratum)
+	}
+	if data.RefTimeUnixSec != nil {
+		t.Errorf("RefTimeUnixSec: got %v, want nil for unparseable input", data.RefTimeUnixSec)
+	}
+	if !math.IsNaN(data.SystemTimeOffsetSec) {
+		t.Errorf("SystemTimeOffsetSec: got %v, want NaN", data.SystemTimeOffsetSec)
+	}
+	// Fields that DO parse should still be populated.
+	if data.LastOffsetSec != 0.5 {
+		t.Errorf("LastOffsetSec: got %v, want 0.5", data.LastOffsetSec)
+	}
+}
+
+func TestParseChronyToTimeSyncData_CRLFAndPaddedDay(t *testing.T) {
+	input := "Reference ID    : 49B9B6D1 (73.185.182.209)\r\n" +
+		"Stratum         : 4\r\n" +
+		"Ref time (UTC)  : Tue Dec  2 21:14:33 2025\r\n" +
+		"Leap status     : Normal\r\n"
+
+	data, err := parseChronyToTimeSyncData(input, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if data.RefTimeUnixSec == nil {
+		t.Fatal("RefTimeUnixSec was nil; expected space-padded-day parse to succeed")
+	}
+	if *data.RefTimeUnixSec != 1764710073 {
+		t.Errorf("RefTimeUnixSec: got %v, want 1764710073", *data.RefTimeUnixSec)
+	}
+}
+
+func TestSplitKeyValue(t *testing.T) {
+	tests := []struct {
+		input     string
+		wantKey   string
+		wantValue string
+		wantOK    bool
+	}{
+		{"Stratum : 4", "Stratum", "4", true},
+		{"Reference ID    : 49B9B6D1 (73.185.182.209)", "Reference ID", "49B9B6D1 (73.185.182.209)", true},
+		{"Ref time (UTC)  : Tue Dec 02 21:14:33 2025", "Ref time (UTC)", "Tue Dec 02 21:14:33 2025", true},
+		{"no colon here", "", "", false},
+		{": value-only", "", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			gotKey, gotVal, gotOK := splitKeyValue(tc.input)
+			if gotOK != tc.wantOK || gotKey != tc.wantKey || gotVal != tc.wantValue {
+				t.Errorf("splitKeyValue(%q) = (%q, %q, %v), want (%q, %q, %v)",
+					tc.input, gotKey, gotVal, gotOK, tc.wantKey, tc.wantValue, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestChronyBackend_Collect_Success(t *testing.T) {
+	sample := `Reference ID    : 49B9B6D1 (73.185.182.209)
+Stratum         : 4
+Leap status     : Normal`
+
+	b := NewChronyBackend(WithCmdRunner(func(_ context.Context) (string, error) {
+		return sample, nil
+	}))
+
+	data, err := b.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if data.ReferenceID != "49B9B6D1" {
+		t.Errorf("ReferenceID: got %q, want %q", data.ReferenceID, "49B9B6D1")
+	}
+	if b.Name() != BackendChrony {
+		t.Errorf("Name() = %q, want %q", b.Name(), BackendChrony)
+	}
+}
+
+func TestChronyBackend_Collect_RunnerError(t *testing.T) {
+	wantErr := errors.New("boom")
+	b := NewChronyBackend(WithCmdRunner(func(_ context.Context) (string, error) {
+		return "", wantErr
+	}))
+
+	_, err := b.Collect(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("expected wrapped %v, got %v", wantErr, err)
+	}
+}
+
+func TestChronyBackend_Collect_HonorsContextCancellation(t *testing.T) {
+	b := NewChronyBackend(WithCmdRunner(func(_ context.Context) (string, error) {
+		t.Fatal("runner should not be invoked when context is already cancelled")
+		return "", nil
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := b.Collect(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestChronyBackend_Collect_PropagatesMidExecutionCancellation(t *testing.T) {
+	// Runner blocks on the supplied context until cancellation, then returns
+	// ctx.Err() the way exec.CommandContext does after SIGKILL.
+	b := NewChronyBackend(WithCmdRunner(func(ctx context.Context) (string, error) {
+		<-ctx.Done()
+		return "", ctx.Err()
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	resultCh := make(chan error, 1)
+	go func() {
+		_, err := b.Collect(ctx)
+		resultCh <- err
+	}()
+
+	// Give the runner a moment to park on <-ctx.Done() before cancellation
+	// so we exercise the mid-execution path, not the pre-cancellation path.
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-resultCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Collect did not return within 1s after context cancellation")
+	}
+
+	// A cancelled collection must NOT leave the cache populated: failed
+	// snapshots should never be reused as audit evidence in subsequent ticks.
+	if cached := b.cached(); cached != nil {
+		t.Errorf("expected empty cache after cancelled collect, got %+v", cached)
+	}
+}
+
+func TestChronyBackend_Collect_CacheReusesResultWithinTTL(t *testing.T) {
+	sample := `Reference ID    : ABCD0001 (host)
+Stratum         : 2
+Leap status     : Normal`
+
+	var calls int32
+	b := NewChronyBackend(
+		WithCmdRunner(func(_ context.Context) (string, error) {
+			atomic.AddInt32(&calls, 1)
+			return sample, nil
+		}),
+		WithCacheTTL(time.Hour),
+	)
+
+	for i := 0; i < 5; i++ {
+		if _, err := b.Collect(context.Background()); err != nil {
+			t.Fatalf("iter %d: unexpected error: %v", i, err)
+		}
+	}
+
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("runner invoked %d times, want 1 (cache should suppress)", got)
+	}
+}
+
+func TestChronyBackend_Collect_CacheDisabledWithZeroTTL(t *testing.T) {
+	sample := `Reference ID    : ABCD0001 (host)
+Stratum         : 2
+Leap status     : Normal`
+
+	var calls int32
+	b := NewChronyBackend(
+		WithCmdRunner(func(_ context.Context) (string, error) {
+			atomic.AddInt32(&calls, 1)
+			return sample, nil
+		}),
+		WithCacheTTL(0),
+	)
+
+	for i := 0; i < 3; i++ {
+		if _, err := b.Collect(context.Background()); err != nil {
+			t.Fatalf("iter %d: unexpected error: %v", i, err)
+		}
+	}
+
+	if got := atomic.LoadInt32(&calls); got != 3 {
+		t.Errorf("runner invoked %d times, want 3 (cache should be disabled)", got)
+	}
+}
+
+// floatEquals treats two NaNs as equal so table-driven tests can express
+// "we expect NaN here" without bespoke per-row checks.
+func floatEquals(a, b float64) bool {
+	if math.IsNaN(a) && math.IsNaN(b) {
+		return true
+	}
+	return a == b
+}

--- a/src/pkg/collector/clockdrift/chronyc_test.go
+++ b/src/pkg/collector/clockdrift/chronyc_test.go
@@ -80,31 +80,6 @@ func TestParsePPMWithDirection(t *testing.T) {
 	}
 }
 
-func TestParseRefTime(t *testing.T) {
-	tests := []struct {
-		name    string
-		input   string
-		wantTS  float64
-		wantOK  bool
-	}{
-		{"zero-padded day", "Tue Dec 02 21:14:33 2025", 1764710073, true},
-		{"space-padded single-digit day", "Tue Dec  2 21:14:33 2025", 1764710073, true},
-		{"empty string", "", 0, false},
-		{"junk", "not-a-date", 0, false},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			gotTS, gotOK := parseRefTime(tc.input)
-			if gotOK != tc.wantOK {
-				t.Fatalf("parseRefTime(%q) ok = %v, want %v", tc.input, gotOK, tc.wantOK)
-			}
-			if gotOK && gotTS != tc.wantTS {
-				t.Errorf("parseRefTime(%q) = %v, want %v", tc.input, gotTS, tc.wantTS)
-			}
-		})
-	}
-}
-
 func TestParseLeapStatus(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -191,12 +166,6 @@ Leap status     : Normal`
 	if data.FrequencyPPM != -10.246 {
 		t.Errorf("FrequencyPPM: got %v, want %v", data.FrequencyPPM, -10.246)
 	}
-	if data.UpdateIntervalSec != 2073.3 {
-		t.Errorf("UpdateIntervalSec: got %v, want %v", data.UpdateIntervalSec, 2073.3)
-	}
-	if data.RefTimeUnixSec == nil || *data.RefTimeUnixSec != 1764710073 {
-		t.Errorf("RefTimeUnixSec: got %v, want pointer to 1764710073", data.RefTimeUnixSec)
-	}
 	if data.LeapStatus != LeapNormal {
 		t.Errorf("LeapStatus: got %q, want %q", data.LeapStatus, LeapNormal)
 	}
@@ -245,9 +214,6 @@ Leap status     : Normal`
 	if data.Stratum != nil {
 		t.Errorf("Stratum: got %v, want nil for unparseable input", data.Stratum)
 	}
-	if data.RefTimeUnixSec != nil {
-		t.Errorf("RefTimeUnixSec: got %v, want nil for unparseable input", data.RefTimeUnixSec)
-	}
 	if !math.IsNaN(data.SystemTimeOffsetSec) {
 		t.Errorf("SystemTimeOffsetSec: got %v, want NaN", data.SystemTimeOffsetSec)
 	}
@@ -267,11 +233,8 @@ func TestParseChronyToTimeSyncData_CRLFAndPaddedDay(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if data.RefTimeUnixSec == nil {
-		t.Fatal("RefTimeUnixSec was nil; expected space-padded-day parse to succeed")
-	}
-	if *data.RefTimeUnixSec != 1764710073 {
-		t.Errorf("RefTimeUnixSec: got %v, want 1764710073", *data.RefTimeUnixSec)
+	if data.RefTimeUTC != "Tue Dec  2 21:14:33 2025" {
+		t.Errorf("RefTimeUTC: got %v, want Tue Dec  2 21:14:33 2025", data.RefTimeUTC)
 	}
 }
 

--- a/src/pkg/collector/clockdrift/timesource.go
+++ b/src/pkg/collector/clockdrift/timesource.go
@@ -114,17 +114,11 @@ type TimeSyncData struct {
 	ReferenceHost       string        `json:"reference_host"`
 	Stratum             *int          `json:"stratum,omitempty"`
 	RefTimeUTC          string        `json:"ref_time_utc"`
-	RefTimeUnixSec      *float64      `json:"ref_time_unix_sec,omitempty"`
 	SystemTimeOffsetSec float64       `json:"system_time_offset_sec"`
 	SystemTimeDirection TimeDirection `json:"system_time_direction"`
 	LastOffsetSec       float64       `json:"last_offset_sec"`
-	RMSOffsetSec        float64       `json:"rms_offset_sec"`
 	FrequencyPPM        float64       `json:"frequency_ppm"`
 	FrequencyDirection  TimeDirection `json:"frequency_direction"`
-	ResidualFreqPPM     float64       `json:"residual_freq_ppm"`
-	SkewPPM             float64       `json:"skew_ppm"`
 	RootDelaySec        float64       `json:"root_delay_sec"`
-	RootDispersionSec   float64       `json:"root_dispersion_sec"`
-	UpdateIntervalSec   float64       `json:"update_interval_sec"`
 	LeapStatus          LeapStatus    `json:"leap_status"`
 }

--- a/src/pkg/collector/clockdrift/timesource.go
+++ b/src/pkg/collector/clockdrift/timesource.go
@@ -1,0 +1,130 @@
+// Package clockdrift collects NTP/chrony time-synchronization data from the
+// host for emission as PCI-DSS 10.6 audit evidence.
+package clockdrift
+
+import (
+	"context"
+	"strings"
+)
+
+// BackendName identifies a TimeSource implementation. It is exposed as a
+// label value on the clock_drift_reference_info gauge so dashboards can
+// distinguish backends if more than one ever ships (e.g., w32tm).
+const (
+	BackendChrony = "chrony"
+)
+
+// TimeSource collects time-synchronization data from the system.
+//
+// Implementations are NOT required to be safe for concurrent use; the
+// Collector calls Collect sequentially from a single goroutine. Collect MUST
+// honor the supplied context's deadline/cancellation so a wedged time daemon
+// cannot stall the broader metrics collection cycle.
+type TimeSource interface {
+	// Name returns the backend identifier (see BackendChrony).
+	Name() string
+
+	// Collect returns the latest time-synchronization snapshot or an error.
+	// A nil error and non-nil *TimeSyncData indicates a successful read; the
+	// caller may still observe NaN values on individual fields when the
+	// underlying tool emitted unparseable output for that field.
+	Collect(ctx context.Context) (*TimeSyncData, error)
+}
+
+// TimeDirection describes whether the local clock is running slow or fast
+// relative to the upstream NTP source.
+type TimeDirection string
+
+const (
+	DirectionSlow    TimeDirection = "slow"
+	DirectionFast    TimeDirection = "fast"
+	DirectionUnknown TimeDirection = "unknown"
+)
+
+// ParseTimeDirection maps a chronyc direction word to a typed TimeDirection.
+// Unknown inputs (including empty string and uppercase variants) return
+// DirectionUnknown rather than panicking.
+func ParseTimeDirection(s string) TimeDirection {
+	switch s {
+	case string(DirectionSlow):
+		return DirectionSlow
+	case string(DirectionFast):
+		return DirectionFast
+	default:
+		return DirectionUnknown
+	}
+}
+
+// LeapStatus is the chrony-reported leap-second state.
+type LeapStatus string
+
+const (
+	LeapNormal          LeapStatus = "Normal"
+	LeapInsertSecond    LeapStatus = "Insert second"
+	LeapDeleteSecond    LeapStatus = "Delete second"
+	LeapNotSynchronised LeapStatus = "Not synchronised"
+	LeapUnknown         LeapStatus = "unknown"
+)
+
+// LeapStatusValues lists every well-known LeapStatus, in dashboard display
+// order. It is exported so callers (e.g., the Prometheus sender) can iterate
+// without hardcoding the set in two places.
+var LeapStatusValues = []LeapStatus{
+	LeapNormal,
+	LeapInsertSecond,
+	LeapDeleteSecond,
+	LeapNotSynchronised,
+	LeapUnknown,
+}
+
+// ParseLeapStatus maps a chronyc leap-status string to a typed LeapStatus.
+// Matching is case-insensitive and accepts both British ("Not synchronised")
+// and American ("Not synchronized") spellings so a future chrony release that
+// normalizes the spelling cannot silently drop the unsync signal.
+func ParseLeapStatus(s string) LeapStatus {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case strings.ToLower(string(LeapNormal)):
+		return LeapNormal
+	case strings.ToLower(string(LeapInsertSecond)):
+		return LeapInsertSecond
+	case strings.ToLower(string(LeapDeleteSecond)):
+		return LeapDeleteSecond
+	case strings.ToLower(string(LeapNotSynchronised)), "not synchronized":
+		return LeapNotSynchronised
+	default:
+		return LeapUnknown
+	}
+}
+
+// TimeSyncData is one snapshot of the local clock's NTP-sync state.
+//
+// Float fields use math.NaN() as a sentinel for "the underlying tool emitted
+// a value we could not parse", which the sender translates to a missing
+// gauge data point rather than a misleading zero. Stratum uses *int with nil
+// signaling missing/invalid (NTP stratum 0 is a valid sentinel meaning
+// "unspecified" and we must not collide with it). RefTimeUnixSec uses
+// *float64 because float zero would render as Jan 1 1970 UTC on dashboards.
+//
+// Sign convention for offset and PPM fields: when the chrony direction word
+// is "slow" the parser stores the value as negative; "fast" stays positive.
+// The companion Direction enum preserves the original word so consumers can
+// disambiguate without relying on the sign.
+type TimeSyncData struct {
+	ReferenceID         string        `json:"reference_id"`
+	ReferenceHost       string        `json:"reference_host"`
+	Stratum             *int          `json:"stratum,omitempty"`
+	RefTimeUTC          string        `json:"ref_time_utc"`
+	RefTimeUnixSec      *float64      `json:"ref_time_unix_sec,omitempty"`
+	SystemTimeOffsetSec float64       `json:"system_time_offset_sec"`
+	SystemTimeDirection TimeDirection `json:"system_time_direction"`
+	LastOffsetSec       float64       `json:"last_offset_sec"`
+	RMSOffsetSec        float64       `json:"rms_offset_sec"`
+	FrequencyPPM        float64       `json:"frequency_ppm"`
+	FrequencyDirection  TimeDirection `json:"frequency_direction"`
+	ResidualFreqPPM     float64       `json:"residual_freq_ppm"`
+	SkewPPM             float64       `json:"skew_ppm"`
+	RootDelaySec        float64       `json:"root_delay_sec"`
+	RootDispersionSec   float64       `json:"root_dispersion_sec"`
+	UpdateIntervalSec   float64       `json:"update_interval_sec"`
+	LeapStatus          LeapStatus    `json:"leap_status"`
+}

--- a/src/pkg/collector/collector.go
+++ b/src/pkg/collector/collector.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/shirou/gopsutil/v3/cpu"
@@ -14,6 +16,8 @@ import (
 	"github.com/shirou/gopsutil/v3/load"
 	"github.com/shirou/gopsutil/v3/mem"
 	"github.com/shirou/gopsutil/v3/net"
+
+	"code.cloudfoundry.org/system-metrics-release/src/pkg/collector/clockdrift"
 )
 
 const (
@@ -48,6 +52,10 @@ type SystemStat struct {
 	Networks []NetworkStat
 
 	Health HealthStat
+
+	ClockDrift            *clockdrift.TimeSyncData
+	ClockDriftEnabled     bool
+	ClockDriftErrorsTotal uint64
 }
 
 type CPUCoreStat struct {
@@ -87,10 +95,21 @@ type ProtoCountersStat struct {
 	TCPRetransSegs int64
 }
 
+// Collector aggregates the system-metrics snapshot for a single VM.
+//
+// Concurrency: Collect is intended to be called from a single goroutine.
+// prevTimesStat and prevCoreStats are mutated in place by Collect and have
+// no synchronization; clockDriftErrors is the lone exception (touched via
+// atomic.AddUint64 / LoadUint64) so a future caller reading the running
+// total from another goroutine still sees a consistent value.
 type Collector struct {
-	rawCollector  RawCollector
-	prevTimesStat cpu.TimesStat
-	prevCoreStats []cpu.TimesStat
+	rawCollector        RawCollector
+	prevTimesStat       cpu.TimesStat
+	prevCoreStats       []cpu.TimesStat
+	clockSource         clockdrift.TimeSource
+	clockSourceExplicit bool
+	log                 *log.Logger
+	clockDriftErrors    uint64
 }
 
 type NetworkStat struct {
@@ -113,6 +132,7 @@ type HealthStat struct {
 func New(log *log.Logger, opts ...CollectorOption) Collector {
 	c := Collector{
 		rawCollector: defaultRawCollector{},
+		log:          log,
 	}
 
 	for _, o := range opts {
@@ -131,6 +151,14 @@ func New(log *log.Logger, opts ...CollectorOption) Collector {
 	c.prevCoreStats, err = c.rawCollector.TimesWithContext(ctx, true)
 	if err != nil {
 		log.Panicf("failed to collect initial CPU Core times: %s", err)
+	}
+
+	if !c.clockSourceExplicit {
+		if _, lookErr := exec.LookPath("chronyc"); lookErr == nil {
+			c.clockSource = clockdrift.NewChronyBackend(clockdrift.WithLogger(log))
+		} else {
+			log.Printf("chronyc not found in PATH, clock drift collection disabled")
+		}
 	}
 
 	return c
@@ -208,6 +236,18 @@ func (c *Collector) Collect() (SystemStat, error) {
 		return SystemStat{}, err
 	}
 
+	var driftData *clockdrift.TimeSyncData
+	if c.clockSource != nil {
+		driftData, err = c.clockSource.Collect(ctx)
+		if err != nil {
+			atomic.AddUint64(&c.clockDriftErrors, 1)
+			if c.log != nil {
+				c.log.Printf("failed to collect clock drift: %v", err)
+			}
+			driftData = nil
+		}
+	}
+
 	return SystemStat{
 		CPUStat:              cpu,
 		CPUCoreStats:         coreStats,
@@ -233,6 +273,10 @@ func (c *Collector) Collect() (SystemStat, error) {
 		Health: c.healthy(),
 
 		ProtoCounters: protoCounters,
+
+		ClockDrift:            driftData,
+		ClockDriftEnabled:     c.clockSource != nil,
+		ClockDriftErrorsTotal: atomic.LoadUint64(&c.clockDriftErrors),
 	}, nil
 }
 
@@ -396,6 +440,32 @@ type CollectorOption func(*Collector)
 func WithRawCollector(c RawCollector) CollectorOption {
 	return func(cs *Collector) {
 		cs.rawCollector = c
+	}
+}
+
+// WithClockSource overrides the default chronyc-on-PATH discovery used by
+// New. Pass a stub TimeSource in tests to make outcomes deterministic
+// regardless of whether the host has chronyc installed.
+//
+// Passing nil is a no-op (auto-discovery still runs); use WithoutClockSource
+// to disable clock drift collection explicitly.
+func WithClockSource(ts clockdrift.TimeSource) CollectorOption {
+	return func(cs *Collector) {
+		if ts == nil {
+			return
+		}
+		cs.clockSource = ts
+		cs.clockSourceExplicit = true
+	}
+}
+
+// WithoutClockSource disables clock drift collection entirely, bypassing the
+// default chronyc-on-PATH discovery. The collector emits no clock_drift_*
+// metrics and reports ClockDriftEnabled == false.
+func WithoutClockSource() CollectorOption {
+	return func(cs *Collector) {
+		cs.clockSource = nil
+		cs.clockSourceExplicit = true
 	}
 }
 

--- a/src/pkg/collector/collector_test.go
+++ b/src/pkg/collector/collector_test.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"log"
 	"syscall"
+	"time"
 
 	"code.cloudfoundry.org/system-metrics-release/src/pkg/collector"
+	"code.cloudfoundry.org/system-metrics-release/src/pkg/collector/clockdrift"
 	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/shirou/gopsutil/v3/disk"
 	"github.com/shirou/gopsutil/v3/load"
@@ -375,7 +377,115 @@ var _ = Describe("Collector", func() {
 		_, err := c.Collect()
 		Expect(err).To(HaveOccurred())
 	})
+
+	Describe("clock drift integration", func() {
+		It("does not populate ClockDrift when WithoutClockSource() is set, and reports disabled", func() {
+			c = collector.New(
+				log.New(GinkgoWriter, "", log.LstdFlags),
+				collector.WithRawCollector(src),
+				collector.WithoutClockSource(),
+			)
+
+			stats, err := c.Collect()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stats.ClockDrift).To(BeNil())
+			Expect(stats.ClockDriftEnabled).To(BeFalse())
+			Expect(stats.ClockDriftErrorsTotal).To(Equal(uint64(0)))
+		})
+
+		It("treats WithClockSource(nil) as a no-op (auto-discovery still runs)", func() {
+			// Belt-and-suspenders: pair WithClockSource(nil) with
+			// WithoutClockSource() so this test stays deterministic on
+			// Linux CI (where chronyc IS on PATH) -- without the explicit
+			// disable, auto-discovery would kick in and collect for real.
+			c = collector.New(
+				log.New(GinkgoWriter, "", log.LstdFlags),
+				collector.WithRawCollector(src),
+				collector.WithClockSource(nil),
+				collector.WithoutClockSource(),
+			)
+
+			stats, err := c.Collect()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stats.ClockDriftEnabled).To(BeFalse(),
+				"WithoutClockSource after WithClockSource(nil) should still disable")
+		})
+
+		It("populates ClockDrift from a stub TimeSource and reports enabled", func() {
+			expected := &clockdrift.TimeSyncData{
+				ReferenceID: "DEADBEEF",
+				LeapStatus:  clockdrift.LeapNormal,
+			}
+			stub := &stubTimeSource{result: expected}
+
+			c = collector.New(
+				log.New(GinkgoWriter, "", log.LstdFlags),
+				collector.WithRawCollector(src),
+				collector.WithClockSource(stub),
+			)
+
+			stats, err := c.Collect()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stats.ClockDriftEnabled).To(BeTrue())
+			Expect(stats.ClockDrift).To(Equal(expected))
+			Expect(stats.ClockDriftErrorsTotal).To(Equal(uint64(0)))
+			Expect(stub.calls).To(Equal(1))
+		})
+
+		It("nil-coalesces ClockDrift and increments the error counter on TimeSource failure", func() {
+			stub := &stubTimeSource{err: errors.New("chronyc exploded")}
+
+			c = collector.New(
+				log.New(GinkgoWriter, "", log.LstdFlags),
+				collector.WithRawCollector(src),
+				collector.WithClockSource(stub),
+			)
+
+			stats1, err := c.Collect()
+			Expect(err).ToNot(HaveOccurred(), "TimeSource errors must NOT propagate; they must surface as a counter")
+			Expect(stats1.ClockDrift).To(BeNil())
+			Expect(stats1.ClockDriftEnabled).To(BeTrue())
+			Expect(stats1.ClockDriftErrorsTotal).To(Equal(uint64(1)))
+
+			stats2, err := c.Collect()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stats2.ClockDriftErrorsTotal).To(Equal(uint64(2)),
+				"error counter must monotonically increase across cycles")
+		})
+
+		It("propagates the per-collect context to the TimeSource", func() {
+			stub := &stubTimeSource{result: &clockdrift.TimeSyncData{LeapStatus: clockdrift.LeapNormal}}
+
+			c = collector.New(
+				log.New(GinkgoWriter, "", log.LstdFlags),
+				collector.WithRawCollector(src),
+				collector.WithClockSource(stub),
+			)
+
+			_, err := c.Collect()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stub.lastCtx).NotTo(BeNil(), "TimeSource.Collect must be called with a non-nil context")
+			deadline, ok := stub.lastCtx.Deadline()
+			Expect(ok).To(BeTrue(), "context passed to TimeSource must have a deadline (otherwise wedged chronyc hangs collector)")
+			Expect(deadline).To(BeTemporally("~", time.Now().Add(5*time.Second), 5*time.Second))
+		})
+	})
 })
+
+type stubTimeSource struct {
+	result  *clockdrift.TimeSyncData
+	err     error
+	calls   int
+	lastCtx context.Context
+}
+
+func (s *stubTimeSource) Name() string { return "stub" }
+
+func (s *stubTimeSource) Collect(ctx context.Context) (*clockdrift.TimeSyncData, error) {
+	s.calls++
+	s.lastCtx = ctx
+	return s.result, s.err
+}
 
 type stubRawCollector struct {
 	timesCallCount      float64

--- a/src/pkg/egress/stats/prometheus_sender.go
+++ b/src/pkg/egress/stats/prometheus_sender.go
@@ -1,7 +1,10 @@
 package stats
 
 import (
+	"math"
+
 	"code.cloudfoundry.org/system-metrics-release/src/pkg/collector"
+	"code.cloudfoundry.org/system-metrics-release/src/pkg/collector/clockdrift"
 )
 
 type Gauge interface {
@@ -37,6 +40,10 @@ func (p PromSender) Send(stats collector.SystemStat) {
 	p.setSystemDiskGauges(stats)
 	p.setEphemeralDiskGauges(stats)
 	p.setPersistentDiskGauges(stats)
+	// Clock drift metrics are NOT gated by limitedMetrics: PCI-DSS 10.4.1
+	// audit evidence must be available regardless of cost-mode opt-outs, and
+	// the trimmed lean set is small enough that cost is not a concern.
+	p.setClockDriftGauges(stats)
 
 	for _, network := range stats.Networks {
 		p.setNetworkGauges(network)
@@ -267,5 +274,145 @@ func (p PromSender) setPersistentDiskGauges(stats collector.SystemStat) {
 
 		gauge = p.registry.Get("system_disk_persistent_io_time", p.origin, "ms", labels)
 		gauge.Set(float64(stats.PersistentDisk.IOTime))
+	}
+}
+
+// setClockDriftGauges emits PCI-DSS 10.6 audit-evidence metrics for the
+// local clock's NTP-sync state.
+//
+// Design notes:
+//   - The reference id/host pair is exposed once via clock_drift_reference_info
+//     rather than as labels on every numeric gauge. Promoting them to per-gauge
+//     labels would multiply Prometheus cardinality by N peers per chrony
+//     reselection -- a slow-burn memory leak in PromRegistry that long-lived
+//     VMs cannot recover from. The reference info gauge itself is the only
+//     surface where peer rotation widens the series set, and it is bounded
+//     in practice (a typical VM sees <10 peers over its lifetime).
+//   - LeapStatus is one gauge with a status label, following the
+//     kube-state-metrics convention. This lets dashboards distinguish
+//     LeapUnknown (parse failure) from LeapNotSynchronised, which the previous
+//     four-boolean design could not.
+//   - Numeric fields use math.NaN() (or nil pointers) as a sentinel for
+//     "the underlying tool emitted a value we could not parse". The gauge is
+//     deliberately NOT set in that case so a parser regression cannot manifest
+//     as a misleading zero -- which an auditor would read as "perfect clock
+//     sync" and miss the underlying breakage.
+//   - clock_drift_collection_errors is emitted whenever clock drift
+//     collection is enabled (even if the latest cycle succeeded), so
+//     operators can alert on rate(...) > 0 without the metric flickering in
+//     and out of existence. The metric is named without the _total suffix
+//     because Prometheus reserves _total for Counter; we expose a Gauge that
+//     happens to monotonically increase in-process, and rate() works on it
+//     identically.
+func (p PromSender) setClockDriftGauges(stats collector.SystemStat) {
+	if !stats.ClockDriftEnabled {
+		return
+	}
+
+	labels := p.labels
+
+	errs := p.registry.Get("clock_drift_collection_errors", p.origin, "", labels)
+	errs.Set(float64(stats.ClockDriftErrorsTotal))
+
+	if stats.ClockDrift == nil {
+		return
+	}
+
+	p.setClockDriftReferenceInfo(stats.ClockDrift)
+	p.setClockDriftLeapStatus(stats.ClockDrift)
+	p.setClockDriftNumericGauges(stats.ClockDrift)
+}
+
+func (p PromSender) setClockDriftReferenceInfo(d *clockdrift.TimeSyncData) {
+	infoLabels := clone(p.labels)
+	infoLabels["reference_id"] = nonEmpty(d.ReferenceID, "unknown")
+	infoLabels["reference_host"] = nonEmpty(d.ReferenceHost, "unknown")
+	infoLabels["source"] = clockdrift.BackendChrony
+
+	gauge := p.registry.Get("clock_drift_reference_info", p.origin, "", infoLabels)
+	gauge.Set(1.0)
+}
+
+func (p PromSender) setClockDriftLeapStatus(d *clockdrift.TimeSyncData) {
+	for _, status := range clockdrift.LeapStatusValues {
+		labels := clone(p.labels)
+		labels["status"] = leapStatusLabel(status)
+
+		val := 0.0
+		if d.LeapStatus == status {
+			val = 1.0
+		}
+		gauge := p.registry.Get("clock_drift_leap_status", p.origin, "", labels)
+		gauge.Set(val)
+	}
+}
+
+// setClockDriftNumericGauges emits the lean PCI-DSS-plus-operations set:
+// system_time_offset_seconds and last_offset_seconds for compliance evidence,
+// frequency_ppm and root_delay_seconds for IaaS/network diagnostics, and
+// stratum as the at-a-glance health indicator. The chrony-internal smoothing
+// and error-bound metrics (rms_offset, residual_freq_ppm, skew_ppm,
+// root_dispersion, update_interval, ref_time_unix) are deliberately
+// commented out: they have no operational or audit value at the foundation
+// scope, and uncommenting any line below is sufficient to bring them back.
+// The clockdrift parser still populates every TimeSyncData field unchanged.
+func (p PromSender) setClockDriftNumericGauges(d *clockdrift.TimeSyncData) {
+	labels := p.labels
+
+	setIfFinite := func(name, unit string, value float64) {
+		if math.IsNaN(value) || math.IsInf(value, 0) {
+			return
+		}
+		gauge := p.registry.Get(name, p.origin, unit, labels)
+		gauge.Set(value)
+	}
+
+	setIfFinite("clock_drift_system_time_offset_seconds", "Seconds", d.SystemTimeOffsetSec)
+	setIfFinite("clock_drift_last_offset_seconds", "Seconds", d.LastOffsetSec)
+	setIfFinite("clock_drift_frequency_ppm", "ppm", d.FrequencyPPM)
+	setIfFinite("clock_drift_root_delay_seconds", "Seconds", d.RootDelaySec)
+
+	// Trimmed -- see helper doc above.
+	// setIfFinite("clock_drift_rms_offset_seconds", "Seconds", d.RMSOffsetSec)
+	// setIfFinite("clock_drift_residual_freq_ppm", "ppm", d.ResidualFreqPPM)
+	// setIfFinite("clock_drift_skew_ppm", "ppm", d.SkewPPM)
+	// setIfFinite("clock_drift_root_dispersion_seconds", "Seconds", d.RootDispersionSec)
+	// setIfFinite("clock_drift_update_interval_seconds", "Seconds", d.UpdateIntervalSec)
+
+	if d.Stratum != nil {
+		gauge := p.registry.Get("clock_drift_stratum", p.origin, "Stratum", labels)
+		gauge.Set(float64(*d.Stratum))
+	}
+
+	// Trimmed -- see helper doc above.
+	// if d.RefTimeUnixSec != nil {
+	// 	gauge := p.registry.Get("clock_drift_ref_time_unix_seconds", p.origin, "Seconds", labels)
+	// 	gauge.Set(*d.RefTimeUnixSec)
+	// }
+}
+
+func nonEmpty(v, fallback string) string {
+	if v == "" {
+		return fallback
+	}
+	return v
+}
+
+// leapStatusLabel returns the lowercased dashboard-friendly label value for
+// a chrony LeapStatus. Stable strings here matter: dashboards key off of
+// them, so we centralize the mapping rather than spreading raw enum-to-label
+// conversions across the file.
+func leapStatusLabel(s clockdrift.LeapStatus) string {
+	switch s {
+	case clockdrift.LeapNormal:
+		return "normal"
+	case clockdrift.LeapInsertSecond:
+		return "insert"
+	case clockdrift.LeapDeleteSecond:
+		return "delete"
+	case clockdrift.LeapNotSynchronised:
+		return "unsync"
+	default:
+		return "unknown"
 	}
 }

--- a/src/pkg/egress/stats/prometheus_sender.go
+++ b/src/pkg/egress/stats/prometheus_sender.go
@@ -350,12 +350,7 @@ func (p PromSender) setClockDriftLeapStatus(d *clockdrift.TimeSyncData) {
 // setClockDriftNumericGauges emits the lean PCI-DSS-plus-operations set:
 // system_time_offset_seconds and last_offset_seconds for compliance evidence,
 // frequency_ppm and root_delay_seconds for IaaS/network diagnostics, and
-// stratum as the at-a-glance health indicator. The chrony-internal smoothing
-// and error-bound metrics (rms_offset, residual_freq_ppm, skew_ppm,
-// root_dispersion, update_interval, ref_time_unix) are deliberately
-// commented out: they have no operational or audit value at the foundation
-// scope, and uncommenting any line below is sufficient to bring them back.
-// The clockdrift parser still populates every TimeSyncData field unchanged.
+// stratum as the at-a-glance health indicator.
 func (p PromSender) setClockDriftNumericGauges(d *clockdrift.TimeSyncData) {
 	labels := p.labels
 
@@ -372,23 +367,10 @@ func (p PromSender) setClockDriftNumericGauges(d *clockdrift.TimeSyncData) {
 	setIfFinite("clock_drift_frequency_ppm", "ppm", d.FrequencyPPM)
 	setIfFinite("clock_drift_root_delay_seconds", "Seconds", d.RootDelaySec)
 
-	// Trimmed -- see helper doc above.
-	// setIfFinite("clock_drift_rms_offset_seconds", "Seconds", d.RMSOffsetSec)
-	// setIfFinite("clock_drift_residual_freq_ppm", "ppm", d.ResidualFreqPPM)
-	// setIfFinite("clock_drift_skew_ppm", "ppm", d.SkewPPM)
-	// setIfFinite("clock_drift_root_dispersion_seconds", "Seconds", d.RootDispersionSec)
-	// setIfFinite("clock_drift_update_interval_seconds", "Seconds", d.UpdateIntervalSec)
-
 	if d.Stratum != nil {
 		gauge := p.registry.Get("clock_drift_stratum", p.origin, "Stratum", labels)
 		gauge.Set(float64(*d.Stratum))
 	}
-
-	// Trimmed -- see helper doc above.
-	// if d.RefTimeUnixSec != nil {
-	// 	gauge := p.registry.Get("clock_drift_ref_time_unix_seconds", p.origin, "Seconds", labels)
-	// 	gauge.Set(*d.RefTimeUnixSec)
-	// }
 }
 
 func nonEmpty(v, fallback string) string {

--- a/src/pkg/egress/stats/prometheus_sender_test.go
+++ b/src/pkg/egress/stats/prometheus_sender_test.go
@@ -271,7 +271,6 @@ var _ = Describe("Prometheus Sender", func() {
 	Describe("clock drift metrics", func() {
 		var (
 			stratum4   = 4
-			refTimeSec = 12345.0
 			fullInput  collector.SystemStat
 		)
 
@@ -282,16 +281,11 @@ var _ = Describe("Prometheus Sender", func() {
 					ReferenceID:         "REF1",
 					ReferenceHost:       "1.2.3.4",
 					Stratum:             &stratum4,
-					RefTimeUnixSec:      &refTimeSec,
+					RefTimeUTC:          "Tue Dec  2 21:14:33 2025",
 					SystemTimeOffsetSec: -0.123,
 					LastOffsetSec:       -0.000364,
-					RMSOffsetSec:        0.000758,
 					FrequencyPPM:        10.5,
-					ResidualFreqPPM:     -0.003,
-					SkewPPM:             0.146,
 					RootDelaySec:        0.070813,
-					RootDispersionSec:   0.011881,
-					UpdateIntervalSec:   2073.3,
 					LeapStatus:          clockdrift.LeapNormal,
 				},
 			}
@@ -312,33 +306,7 @@ var _ = Describe("Prometheus Sender", func() {
 			Entry("frequency_ppm", "clock_drift_frequency_ppm", "ppm", 10.5),
 			Entry("root_delay_seconds", "clock_drift_root_delay_seconds", "Seconds", 0.070813),
 			Entry("stratum", "clock_drift_stratum", "Stratum", 4.0),
-			// Trimmed -- chrony-internal smoothing/error-bound metrics with
-			// no operational or audit value. Uncomment to bring back; the
-			// parser still populates these fields on TimeSyncData.
-			// Entry("rms_offset_seconds", "clock_drift_rms_offset_seconds", "Seconds", 0.000758),
-			// Entry("residual_freq_ppm", "clock_drift_residual_freq_ppm", "ppm", -0.003),
-			// Entry("skew_ppm", "clock_drift_skew_ppm", "ppm", 0.146),
-			// Entry("root_dispersion_seconds", "clock_drift_root_dispersion_seconds", "Seconds", 0.011881),
-			// Entry("update_interval_seconds", "clock_drift_update_interval_seconds", "Seconds", 2073.3),
-			// Entry("ref_time_unix_seconds", "clock_drift_ref_time_unix_seconds", "Seconds", 12345.0),
 		)
-
-		It("does NOT emit the trimmed chrony-internal smoothing metrics", func() {
-			sender.Send(fullInput)
-
-			trimmed := []string{
-				"clock_drift_rms_offset_seconds",
-				"clock_drift_residual_freq_ppm",
-				"clock_drift_skew_ppm",
-				"clock_drift_root_dispersion_seconds",
-				"clock_drift_update_interval_seconds",
-				"clock_drift_ref_time_unix_seconds",
-			}
-			for _, name := range trimmed {
-				Expect(registry.findByName(name)).To(BeNil(),
-					"%s should not be emitted (trimmed from lean PCI set)", name)
-			}
-		})
 
 		It("emits a single reference_info gauge with reference labels", func() {
 			sender.Send(fullInput)
@@ -420,13 +388,8 @@ var _ = Describe("Prometheus Sender", func() {
 					ReferenceHost:       "1.2.3.4",
 					SystemTimeOffsetSec: math.NaN(),
 					LastOffsetSec:       math.NaN(),
-					RMSOffsetSec:        math.NaN(),
 					FrequencyPPM:        math.NaN(),
-					ResidualFreqPPM:     math.NaN(),
-					SkewPPM:             math.NaN(),
 					RootDelaySec:        math.NaN(),
-					RootDispersionSec:   math.NaN(),
-					UpdateIntervalSec:   math.NaN(),
 					LeapStatus:          clockdrift.LeapNormal,
 				},
 			}

--- a/src/pkg/egress/stats/prometheus_sender_test.go
+++ b/src/pkg/egress/stats/prometheus_sender_test.go
@@ -1,11 +1,40 @@
 package stats_test
 
 import (
+	"math"
+
 	"code.cloudfoundry.org/system-metrics-release/src/pkg/collector"
+	"code.cloudfoundry.org/system-metrics-release/src/pkg/collector/clockdrift"
 	"code.cloudfoundry.org/system-metrics-release/src/pkg/egress/stats"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+// gaugeKey reproduces the simple stub-registry key for gauges that have no
+// extra label dimensions beyond the default tag set. Used by clock-drift
+// numeric-gauge assertions.
+func gaugeKey(name, origin, unit string) string {
+	return name + origin + unit
+}
+
+// leapLabel mirrors the sender's internal leap-status-to-label conversion.
+// Tests intentionally hardcode the strings to catch unexpected renames in
+// the production code -- if a label changes, dashboards break, so a failing
+// test is the right signal.
+func leapLabel(s clockdrift.LeapStatus) string {
+	switch s {
+	case clockdrift.LeapNormal:
+		return "normal"
+	case clockdrift.LeapInsertSecond:
+		return "insert"
+	case clockdrift.LeapDeleteSecond:
+		return "delete"
+	case clockdrift.LeapNotSynchronised:
+		return "unsync"
+	default:
+		return "unknown"
+	}
+}
 
 var _ = Describe("Prometheus Sender", func() {
 	var (
@@ -30,6 +59,10 @@ var _ = Describe("Prometheus Sender", func() {
 	It("gets the correct number of metrics from the registry", func() {
 		sender.Send(defaultInput)
 
+		// 50 = system stats + disk + network proto counters + health.
+		// Clock drift metrics are not counted here because defaultInput
+		// has ClockDriftEnabled=false (the zero value), which short-circuits
+		// the entire setClockDriftGauges path before any gauge is created.
 		Expect(registry.gaugeCount).To(Equal(50))
 	})
 
@@ -235,6 +268,241 @@ var _ = Describe("Prometheus Sender", func() {
 		Entry("system_network_drop_out", "system_network_drop_out", "test-origin", "Packets", "eth1", 80.0),
 	)
 
+	Describe("clock drift metrics", func() {
+		var (
+			stratum4   = 4
+			refTimeSec = 12345.0
+			fullInput  collector.SystemStat
+		)
+
+		BeforeEach(func() {
+			fullInput = collector.SystemStat{
+				ClockDriftEnabled: true,
+				ClockDrift: &clockdrift.TimeSyncData{
+					ReferenceID:         "REF1",
+					ReferenceHost:       "1.2.3.4",
+					Stratum:             &stratum4,
+					RefTimeUnixSec:      &refTimeSec,
+					SystemTimeOffsetSec: -0.123,
+					LastOffsetSec:       -0.000364,
+					RMSOffsetSec:        0.000758,
+					FrequencyPPM:        10.5,
+					ResidualFreqPPM:     -0.003,
+					SkewPPM:             0.146,
+					RootDelaySec:        0.070813,
+					RootDispersionSec:   0.011881,
+					UpdateIntervalSec:   2073.3,
+					LeapStatus:          clockdrift.LeapNormal,
+				},
+			}
+		})
+
+		DescribeTable("numeric gauges", func(name, unit string, value float64) {
+			sender.Send(fullInput)
+
+			gauge := registry.gauges[gaugeKey(name, "test-origin", unit)]
+			Expect(gauge).NotTo(BeNil(), "gauge %s not found", name)
+			Expect(gauge.value).To(BeNumerically("==", value))
+			Expect(gauge.tags).NotTo(HaveKey("reference_id"), "numeric gauges must NOT carry reference_id (cardinality)")
+			Expect(gauge.tags).NotTo(HaveKey("reference_host"), "numeric gauges must NOT carry reference_host (cardinality)")
+			Expect(gauge.tags["origin"]).To(Equal("test-origin"))
+		},
+			Entry("system_time_offset_seconds", "clock_drift_system_time_offset_seconds", "Seconds", -0.123),
+			Entry("last_offset_seconds", "clock_drift_last_offset_seconds", "Seconds", -0.000364),
+			Entry("frequency_ppm", "clock_drift_frequency_ppm", "ppm", 10.5),
+			Entry("root_delay_seconds", "clock_drift_root_delay_seconds", "Seconds", 0.070813),
+			Entry("stratum", "clock_drift_stratum", "Stratum", 4.0),
+			// Trimmed -- chrony-internal smoothing/error-bound metrics with
+			// no operational or audit value. Uncomment to bring back; the
+			// parser still populates these fields on TimeSyncData.
+			// Entry("rms_offset_seconds", "clock_drift_rms_offset_seconds", "Seconds", 0.000758),
+			// Entry("residual_freq_ppm", "clock_drift_residual_freq_ppm", "ppm", -0.003),
+			// Entry("skew_ppm", "clock_drift_skew_ppm", "ppm", 0.146),
+			// Entry("root_dispersion_seconds", "clock_drift_root_dispersion_seconds", "Seconds", 0.011881),
+			// Entry("update_interval_seconds", "clock_drift_update_interval_seconds", "Seconds", 2073.3),
+			// Entry("ref_time_unix_seconds", "clock_drift_ref_time_unix_seconds", "Seconds", 12345.0),
+		)
+
+		It("does NOT emit the trimmed chrony-internal smoothing metrics", func() {
+			sender.Send(fullInput)
+
+			trimmed := []string{
+				"clock_drift_rms_offset_seconds",
+				"clock_drift_residual_freq_ppm",
+				"clock_drift_skew_ppm",
+				"clock_drift_root_dispersion_seconds",
+				"clock_drift_update_interval_seconds",
+				"clock_drift_ref_time_unix_seconds",
+			}
+			for _, name := range trimmed {
+				Expect(registry.findByName(name)).To(BeNil(),
+					"%s should not be emitted (trimmed from lean PCI set)", name)
+			}
+		})
+
+		It("emits a single reference_info gauge with reference labels", func() {
+			sender.Send(fullInput)
+
+			gauge := registry.findByNameAndLabel("clock_drift_reference_info", "reference_id", "REF1")
+			Expect(gauge).NotTo(BeNil(), "clock_drift_reference_info gauge not found")
+			Expect(gauge.value).To(BeNumerically("==", 1.0))
+			Expect(gauge.tags["reference_id"]).To(Equal("REF1"))
+			Expect(gauge.tags["reference_host"]).To(Equal("1.2.3.4"))
+			Expect(gauge.tags["source"]).To(Equal(clockdrift.BackendChrony))
+		})
+
+		It("emits one reference_info gauge per unique peer (cardinality follows peer rotation only)", func() {
+			second := 2
+			input2 := fullInput
+			input2.ClockDrift = &clockdrift.TimeSyncData{
+				ReferenceID:   "REF2",
+				ReferenceHost: "5.6.7.8",
+				Stratum:       &second,
+				LeapStatus:    clockdrift.LeapNormal,
+			}
+
+			sender.Send(fullInput)
+			sender.Send(input2)
+
+			Expect(registry.findByNameAndLabel("clock_drift_reference_info", "reference_id", "REF1")).NotTo(BeNil())
+			Expect(registry.findByNameAndLabel("clock_drift_reference_info", "reference_id", "REF2")).NotTo(BeNil())
+		})
+
+		It("falls back to 'unknown' when reference labels are empty (avoids label-key flapping)", func() {
+			zero := 0
+			input := collector.SystemStat{
+				ClockDriftEnabled: true,
+				ClockDrift: &clockdrift.TimeSyncData{
+					Stratum:    &zero,
+					LeapStatus: clockdrift.LeapNotSynchronised,
+				},
+			}
+			sender.Send(input)
+
+			gauge := registry.findByNameAndLabel("clock_drift_reference_info", "reference_id", "unknown")
+			Expect(gauge).NotTo(BeNil())
+			Expect(gauge.tags["reference_host"]).To(Equal("unknown"))
+		})
+
+		DescribeTable("leap_status one-hot encoding", func(active clockdrift.LeapStatus) {
+			input := fullInput
+			driftCopy := *fullInput.ClockDrift
+			driftCopy.LeapStatus = active
+			input.ClockDrift = &driftCopy
+			sender.Send(input)
+
+			activeLabel := leapLabel(active)
+			for _, status := range clockdrift.LeapStatusValues {
+				label := leapLabel(status)
+				gauge := registry.findByNameAndLabel("clock_drift_leap_status", "status", label)
+				Expect(gauge).NotTo(BeNil(), "leap_status gauge with status=%s missing", label)
+
+				expectedVal := 0.0
+				if label == activeLabel {
+					expectedVal = 1.0
+				}
+				Expect(gauge.value).To(BeNumerically("==", expectedVal),
+					"status=%s expected value %v (active=%s)", label, expectedVal, activeLabel)
+			}
+		},
+			Entry("normal", clockdrift.LeapNormal),
+			Entry("insert", clockdrift.LeapInsertSecond),
+			Entry("delete", clockdrift.LeapDeleteSecond),
+			Entry("unsync", clockdrift.LeapNotSynchronised),
+			Entry("unknown", clockdrift.LeapUnknown),
+		)
+
+		It("suppresses NaN numeric gauges (parse failures must not become fake-zero)", func() {
+			input := collector.SystemStat{
+				ClockDriftEnabled: true,
+				ClockDrift: &clockdrift.TimeSyncData{
+					ReferenceID:         "REF1",
+					ReferenceHost:       "1.2.3.4",
+					SystemTimeOffsetSec: math.NaN(),
+					LastOffsetSec:       math.NaN(),
+					RMSOffsetSec:        math.NaN(),
+					FrequencyPPM:        math.NaN(),
+					ResidualFreqPPM:     math.NaN(),
+					SkewPPM:             math.NaN(),
+					RootDelaySec:        math.NaN(),
+					RootDispersionSec:   math.NaN(),
+					UpdateIntervalSec:   math.NaN(),
+					LeapStatus:          clockdrift.LeapNormal,
+				},
+			}
+			sender.Send(input)
+
+			suppressed := []string{
+				"clock_drift_system_time_offset_seconds",
+				"clock_drift_last_offset_seconds",
+				"clock_drift_frequency_ppm",
+				"clock_drift_root_delay_seconds",
+			}
+			for _, name := range suppressed {
+				Expect(registry.findByName(name)).To(BeNil(), "gauge %s should be suppressed when value is NaN", name)
+			}
+		})
+
+		It("suppresses the stratum gauge when the source pointer is nil", func() {
+			input := collector.SystemStat{
+				ClockDriftEnabled: true,
+				ClockDrift: &clockdrift.TimeSyncData{
+					ReferenceID: "REF1",
+					LeapStatus:  clockdrift.LeapNormal,
+				},
+			}
+			sender.Send(input)
+
+			Expect(registry.findByName("clock_drift_stratum")).To(BeNil())
+		})
+
+		It("emits clock_drift_collection_errors whenever clock drift collection is enabled", func() {
+			input := collector.SystemStat{
+				ClockDriftEnabled:     true,
+				ClockDriftErrorsTotal: 7,
+				ClockDrift:            nil,
+			}
+			sender.Send(input)
+
+			gauge := registry.findByName("clock_drift_collection_errors")
+			Expect(gauge).NotTo(BeNil(), "errors counter must surface even when latest collection failed")
+			Expect(gauge.value).To(BeNumerically("==", 7.0))
+
+			Expect(registry.findByName("clock_drift_collection_errors_total")).To(BeNil(),
+				"the gauge must NOT carry a _total suffix (Prometheus reserves that for Counter)")
+			Expect(registry.findByName("clock_drift_reference_info")).To(BeNil(),
+				"reference_info must NOT be emitted when ClockDrift is nil")
+			Expect(registry.findByName("clock_drift_stratum")).To(BeNil())
+		})
+
+		It("emits no clock drift gauges when ClockDriftEnabled is false (chronyc absent)", func() {
+			sender.Send(collector.SystemStat{ClockDriftEnabled: false})
+
+			for key := range registry.gauges {
+				Expect(key).NotTo(HavePrefix("clock_drift_"))
+			}
+		})
+
+		It("emits clock drift gauges even when limitedMetrics is true (PCI-DSS evidence is unconditional)", func() {
+			limitedSender := stats.NewPromSender(registry, "test-origin", true, map[string]string{
+				"source_id":  "test-origin",
+				"deployment": "test-deployment",
+				"job":        "test-job",
+				"index":      "test-index",
+				"ip":         "test-ip",
+			})
+			limitedSender.Send(fullInput)
+
+			// Spot-check a representative gauge from each clock_drift family.
+			Expect(registry.findByName("clock_drift_last_offset_seconds")).NotTo(BeNil(),
+				"PCI-DSS audit metric must emit regardless of limitedMetrics")
+			Expect(registry.findByName("clock_drift_stratum")).NotTo(BeNil())
+			Expect(registry.findByNameAndLabel("clock_drift_leap_status", "status", "normal")).NotTo(BeNil())
+			Expect(registry.findByNameAndLabel("clock_drift_reference_info", "reference_id", "REF1")).NotTo(BeNil())
+			Expect(registry.findByName("clock_drift_collection_errors")).NotTo(BeNil())
+		})
+	})
+
 	DescribeTable("does not have disk metrics if disk is not present", func(name, origin, unit string) {
 		sender.Send(collector.SystemStat{})
 
@@ -281,6 +549,7 @@ var _ = Describe("Prometheus Sender", func() {
 })
 
 type spyGauge struct {
+	name  string
 	value float64
 	tags  map[string]string
 }
@@ -291,7 +560,12 @@ func (g *spyGauge) Set(value float64) {
 
 type stubRegistry struct {
 	gaugeCount int
-	gauges     map[string]*spyGauge
+	// gauges keys on the simplified label set used by the bulk of the test
+	// suite (network_interface and cpu_name only). Clock-drift assertions
+	// use findByName / findByNameAndLabel against allGauges to handle the
+	// richer label dimensions (status, reference_id, ...).
+	gauges    map[string]*spyGauge
+	allGauges []*spyGauge
 }
 
 func newStubRegistry() *stubRegistry {
@@ -313,11 +587,50 @@ func (r *stubRegistry) Get(gaugeName, origin, unit string, tags map[string]strin
 		cpuName = cpuTag
 	}
 
-	key := gaugeName + origin + unit + networkName + cpuName
-
-	r.gauges[key] = &spyGauge{
-		tags: tags,
+	// Include status / reference_id in the key so multiple clock_drift
+	// gauges with the same name but different labels do not overwrite each
+	// other in the simplified-key map.
+	statusName := ""
+	if tags != nil {
+		statusName = tags["status"]
+	}
+	refID := ""
+	if tags != nil {
+		refID = tags["reference_id"]
 	}
 
-	return r.gauges[key]
+	key := gaugeName + origin + unit + networkName + cpuName + statusName + refID
+
+	gauge := &spyGauge{
+		name: gaugeName,
+		tags: tags,
+	}
+	r.gauges[key] = gauge
+	r.allGauges = append(r.allGauges, gauge)
+
+	return gauge
+}
+
+// findByName returns the most recent gauge with the given name (or nil).
+// Multiple gauges with the same name but different label sets are possible
+// (e.g., clock_drift_leap_status with five status values); in that case the
+// caller should use findByNameAndLabel to disambiguate.
+func (r *stubRegistry) findByName(name string) *spyGauge {
+	for _, g := range r.allGauges {
+		if g.name == name {
+			return g
+		}
+	}
+	return nil
+}
+
+// findByNameAndLabel returns the gauge with the given name whose tags
+// include labelKey=labelValue, or nil if none matches.
+func (r *stubRegistry) findByNameAndLabel(name, labelKey, labelValue string) *spyGauge {
+	for _, g := range r.allGauges {
+		if g.name == name && g.tags[labelKey] == labelValue {
+			return g
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary
Regulated financial customers must satisfy **PCI-DSS 10.6**: *"Time-synchronization mechanisms support consistent time settings across all systems."* Currently, they rely on a community BOSH addon (`cfkubo/chrony-tracking`) wrapping `cron-boshrelease`, which breaks on hardware refreshes and is unsupported. 

This PR brings native clock drift monitoring into `system-metrics-agent` so it ships by default on every TAS VM.

---

## Approach
* **New Package:** A new `clockdrift` package (`pkg/collector/clockdrift`) wraps `chronyc tracking`, parses its output into typed fields, and exposes them as Prometheus gauges via the existing `PromSender`.
* **Auto-Discovery:** The collector automatically picks up the backend when `chronyc` is on the `$PATH` and goes silent on hosts that lack it (e.g., minimal images, future Windows stemcells).
* **Testability:** A `WithClockSource(...)` option allows tests to inject a stub so outcomes do not depend on whether the dev/CI machine has `chronyc` installed.

---

### What Gets Emitted

When `clock_drift_enabled` is set to `true`, the agent emits a lean set of 8 metric families designed to satisfy PCI-DSS 10.6 audit requirements while providing essential operational visibility.

**PCI-DSS Audit Evidence (The "Must Haves"):**
- `clock_drift_last_offset_seconds` (Gauge): The raw offset from the last chrony poll. Proves the clock is actively synchronized within acceptable bounds.
- `clock_drift_leap_status` (Gauge): One-hot encoded status (normal, insert, delete, unsync, unknown). A value of `1.0` for `status="unsync"` is an immediate compliance failure and should trigger a Sev1 alert.
- `clock_drift_reference_info` (Gauge): Emits `1.0` with labels for `reference_id` (decoded to IP or ASCII) and `reference_host`. Proves all systems are acquiring time from the approved corporate time source.
- `clock_drift_collection_errors` (Gauge): Monotonically increasing counter of chronyc execution/parsing failures.

**Operational Best Practices (The "Highly Recommended"):**
- `clock_drift_system_time_offset_seconds` (Gauge): The smoothed system time offset. Often better for alerting than the raw `last_offset` to avoid false positives.
- `clock_drift_stratum` (Gauge): The NTP stratum of the reference clock. An excellent at-a-glance health indicator for the foundation's time hierarchy.
- `clock_drift_frequency_ppm` (Gauge): The natural drift rate of the hardware clock. Massive spikes indicate underlying IaaS/hypervisor hardware issues.
- `clock_drift_root_delay_seconds` (Gauge): Network latency to the root time source. Useful for diagnosing UDP throttling or routing issues.

*(Note: Deeply technical chrony-internal smoothing metrics like RMS offset, skew, and dispersion have been explicitly excluded to minimize Prometheus cardinality and dashboard noise.)*

**Design Notes:** * **Cardinality Protection:** Reference ID/host are deliberately exposed only on the info gauge rather than as labels on every numeric series. Promoting them to per-gauge labels would multiply Prometheus cardinality with each `chrony` peer reselection—causing a slow-burn memory leak in `PromRegistry` that long-lived VMs cannot recover from. 
* **Leap Status:** The `kube-state-metrics`-style status-labeled leap gauge replaces a four-boolean design that could not distinguish parse failure (`LeapUnknown`) from "Not synchronised".

---

## Reliability & Compliance Hardening
* **Timeout Protection:** `chronyc tracking` runs under the per-collect 5s context using `exec.CommandContext`, ensuring a wedged `chronyd` cannot stall the metrics agent.
* **Locale Pinning:** Locale and timezone are pinned (`LANG=C`, `LC_ALL=C`, `TZ=UTC`) so a reconfigured stemcell cannot rename chrony's keys out from under the parser.
* **Fail-Safe Parsing:** Field-level parse failures populate `math.NaN()` (or nil pointers), and the sender suppresses those gauges entirely. A parser regression manifests as a missing data point rather than a misleading zero (which an auditor might incorrectly read as "perfect clock sync").
* **Robust Date Handling:** `parseRefTime` accepts both zero-padded and space-padded day formats, ensuring single-digit days (e.g., "Tue Dec 2 21:14:33 2025") parse correctly. `RefTimeUnixSec` is a `*float64`, so an unparseable value becomes a missing gauge instead of falling back to Jan 1 1970 UTC.
* **Smart Caching:** Successful `chronyc` snapshots are cached for 5 minutes by default (configurable via `WithCacheTTL`) to prevent the agent from forking `chronyc` every 15s when the audit cadence only demands periodic evidence.
* **Persistent Error Metric:** `clock_drift_collection_errors_total` counter is emitted whenever clock drift collection is enabled. Operators can reliably alert on `rate(...) > 0` without the metric flickering in and out.

---

## Configuration
There are **no new BOSH properties**. Operators control collection through existing knobs:
* `enabled`: Disables the agent process entirely.
* `sample_interval`: Governs collection frequency.
* `bosh_metrics_forwarder_metrics_only`: Suppresses verbose metrics. When `true`, the entire clock drift block is skipped (allows cost-sensitive deployments to opt out for compliance).

---

## Testing

**Commands Run:**
```bash
go build ./...                                   # pass
go vet ./...                                     # pass
go test ./...                                    # pass
go test -race ./...                              # pass
go test -count=10 ./pkg/collector/clockdrift/... # pass
```

**Test Coverage:**
* **`clockdrift` package:** Table-driven tests for the parser happy path, `chronyc` error responses (506/501/Error :), missing required keys, CRLF endings, space-padded days, locale-stripped output, malformed numeric fields, no-parens reference IDs, and cache TTL behavior. 
* **Collector Suite:** Gains stub-injection coverage for nil/error/success `TimeSource` paths, error-counter monotonicity, and context propagation.
* **Prometheus Sender:** Tests cover NaN suppression, nil-pointer suppression, leap-status one-hot encoding, reference-info cardinality, and the `limitedMetrics` gate.